### PR TITLE
v0.1.1: Auto-mark test files as viewed (new GitHub React diff UI) + PR list filter

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,63 @@
+name: Publish
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Release tag to retry a failed publish for
+        required: true
+
+env:
+  EXTENSION_ID: dmnfcgnmillpemklpladliejgigipcen
+  TAG: ${{ github.event.release.tag_name || inputs.tag }}
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: chrome-web-store
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.TAG }}
+          persist-credentials: false
+
+      # The store rejects an upload whose version isn't higher than the live one,
+      # so catch a forgotten manifest bump here instead of halfway through publishing.
+      - name: Check manifest version matches the tag
+        run: |
+          manifest=$(jq -r .version manifest.json)
+          tag=${TAG#v}
+          if [ "$manifest" != "$tag" ]; then
+            echo "::error::manifest.json is $manifest but the tag is $tag"
+            exit 1
+          fi
+
+      - name: Build package
+        run: |
+          zip -r pruner.zip \
+            manifest.json src icons _locales \
+            -x '*.DS_Store'
+
+      - name: Upload and publish to the Chrome Web Store
+        uses: puzzlers-labs/chrome-webstore-publish@010fc578dea8e3a05e15af75b836be821ee9ab74 # v1
+        with:
+          mode: publish
+          extension_id: ${{ env.EXTENSION_ID }}
+          zip_file_path: pruner.zip
+          client_id: ${{ secrets.CWS_CLIENT_ID }}
+          client_secret: ${{ secrets.CWS_CLIENT_SECRET }}
+          refresh_token: ${{ secrets.CWS_REFRESH_TOKEN }}
+          # Signs the package so it passes Verified CRX Uploads.
+          crx_private_key: ${{ secrets.CRX_PRIVATE_KEY }}
+
+      # Last, so a rejected upload doesn't leave a download on the release that
+      # never reached the store. The asset is the ZIP, not the signed CRX, because
+      # the README tells people to unzip it and use "Load unpacked".
+      - name: Attach ZIP to the release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload "$TAG" pruner.zip --clobber

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ automatically checks the "Viewed" checkbox on:
 | Pattern | Examples |
 |---|---|
 | `*.test.{ts,tsx,js,jsx,mjs,cjs}` | `button.test.tsx` |
-| `*.spec.{ts,tsx,js,jsx,mjs,cjs}` | `utils.spec.js` |
+| `*.spec.{ts,tsx,js,jsx,mjs,cjs}` | `utils.spec.ts` |
 | `__tests__/` | `__tests__/foo.ts` |
 | `test/` or `tests/` | `test/setup.ts` |
 | `__mocks__/` | `__mocks__/fs.ts` |
@@ -41,6 +41,10 @@ automatically checks the "Viewed" checkbox on:
 
 These files are still visible in the diff — they're just marked "Viewed"
 so they collapse out of your review flow. Focus on the actual logic changes.
+
+> **Toggle on/off:** Right-click the PruneR icon in your toolbar and select
+> "Auto-mark test files as viewed" to enable or disable this feature.
+> A checkmark ✓ means it's active.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -2,13 +2,47 @@
 
 [<img src="https://s3.ap-south-1.amazonaws.com/shared.aashutosh.dev/PruneR.svg" align="right" width="100">](https://pruner.aashutosh.dev)
 
-Dependency management is hard and dependabot like bots makes it easy. But it also floods PR list with a lot of PRs. This extension helps you toggle the visibility of such PRs.
-This reduces the clutter and you can focus on what you have to review.
+Reviewing PRs is hard. Dependabot PRs flood your list, and test file changes add noise to every review. **PruneR** helps you cut through the clutter:
+
+- 🧹 **Hide dependabot / dependency PRs** from the PR list with one click  
+- 👁️ **Auto-mark test files as "Viewed"** on PR file pages so you never have to look at `.test.ts` noise again  
 
 Hence the name *P*rune*R*
 
 > [!NOTE]  
 > This is for very<sup>3</sup> lazy and my kinda people, who don't want to do anything manually.
+
+---
+
+## Features ✨
+
+### 1. Toggle dependency PRs
+
+Click the PruneR icon in your toolbar while you're on a GitHub PR list page
+(`https://github.com/org/repo/pulls`). It adds `-label:dependencies` to the URL,
+hiding all dependabot / dependency PRs in one click. Click again to show them.
+
+### 2. Auto-mark test files as viewed
+
+When you open a PR's **Files changed** tab (`/pull/*/files`), PruneR
+automatically checks the "Viewed" checkbox on:
+
+| Pattern | Examples |
+|---|---|
+| `*.test.{ts,tsx,js,jsx,mjs,cjs}` | `button.test.tsx` |
+| `*.spec.{ts,tsx,js,jsx,mjs,cjs}` | `utils.spec.js` |
+| `__tests__/` | `__tests__/foo.ts` |
+| `test/` or `tests/` | `test/setup.ts` |
+| `__mocks__/` | `__mocks__/fs.ts` |
+| `__fixtures__/`, `fixtures/` | `fixtures/data.json` |
+| `__snapshots__/`, `*.snap` | `__snapshots__/button.test.tsx.snap` |
+| `*.stories.{ts,tsx,js,jsx}` | `button.stories.tsx` |
+| `mock/`, `mocks/` | `mocks/handlers.ts` |
+
+These files are still visible in the diff — they're just marked "Viewed"
+so they collapse out of your review flow. Focus on the actual logic changes.
+
+---
 
 ## Installation
 
@@ -16,21 +50,60 @@ Hence the name *P*rune*R*
 
 [<img src="https://raw.githubusercontent.com/alrra/browser-logos/90fdf03c/src/chrome/chrome.svg" width="48" alt="Chrome" valign="middle">][link-chrome] [<img valign="middle" src="https://img.shields.io/chrome-web-store/v/dmnfcgnmillpemklpladliejgigipcen.svg?label=%20">][link-chrome] and other Chromium browsers
 
+### Install from the latest release 📦
+
+Prefer to run it locally, or want a version before it clears Web Store review?
+
+[link-release]: https://github.com/aashutoshrathi/PruneR/releases/latest 'Latest release'
+
+[<img valign="middle" src="https://img.shields.io/github/v/release/aashutoshrathi/PruneR?label=Download%20latest%20ZIP&style=for-the-badge&logo=github">][link-release]
+
+1. Download the `.zip` from the [latest release][link-release]
+2. Unzip it somewhere you'll keep it — Chrome loads the extension from this folder every time it starts
+3. Open Chrome and navigate to `chrome://extensions/`
+4. Enable **"Developer mode"** (toggle in the top-right corner)
+5. Click **"Load unpacked"** and select the unzipped folder
+6. The PruneR icon should now show up in your toolbar
+
+---
+
 ## Demo 🎥
 
 [![Walkthrough of PruneR](https://img.youtube.com/vi/R--YNMb8tNE/0.jpg)](https://www.youtube.com/watch?v=R--YNMb8tNE "PruneR Demo")
 
+---
+
 ## Development
 
-- Get it locally -
+```sh
+git clone https://github.com/aashutoshrathi/PruneR.git
+cd PruneR
+```
 
-  ```sh
-  git clone https://github.com/aashutoshrathi/PruneR.git
-  ```
+Then load the folder as an unpacked extension in Chrome:
+1. Go to `chrome://extensions/` & enable **Developer Mode**
+2. Click **"Load unpacked"** and select the cloned folder
 
-  **OR**
+---
 
-  Download the latest version here: [PruneR ✨](https://github.com/aashutoshrathi/PruneR/archive/main.zip)
+## Publishing
 
-- Go to `chrome://extensions/` & enable Developer Mode.
-- Click on Load Unpacked Extension and Open/Select the folder.
+A new release triggers a [GitHub Actions workflow](.github/workflows/publish.yml) that:
+
+1. Checks the manifest version matches the release tag
+2. Builds the ZIP package
+3. Publishes to the Chrome Web Store (signed with the Verified CRX key)
+4. Attaches the ZIP to the release
+
+To publish a new version:
+1. Bump `version` in `manifest.json`
+2. Commit: `git commit -m ":arrow_up: bump: vX.Y.Z"`
+3. Tag: `git tag vX.Y.Z`
+4. Push: `git push && git push --tags`
+5. Create a release from the tag on GitHub — the workflow handles the rest
+
+---
+
+## License
+
+MIT © [Aashutosh Rathi](https://aashutosh.dev)

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "PruneR",
   "author": "Aashutosh Rathi",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "manifest_version": 3,
   "description": "Clear PR clutter and auto-dim test files so you focus on what matters",
   "icons": {
@@ -27,7 +27,7 @@
   },
   "content_scripts": [
     {
-      "matches": ["https://github.com/*/*/pull/*/files"],
+      "matches": ["https://github.com/*/*/pull/*"],
       "js": ["src/content.js"],
       "run_at": "document_idle"
     }

--- a/manifest.json
+++ b/manifest.json
@@ -1,9 +1,9 @@
 {
   "name": "PruneR",
   "author": "Aashutosh Rathi",
-  "version": "0.0.4",
+  "version": "0.1.0",
   "manifest_version": 3,
-  "description": "Clear PR clutter to what you want to see",
+  "description": "Clear PR clutter and auto-dim test files so you focus on what matters",
   "icons": {
     "16": "icons/icon16.png",
     "48": "icons/icon48.png",
@@ -23,5 +23,12 @@
   ],
   "background": {
     "service_worker": "src/background.js"
-  }
+  },
+  "content_scripts": [
+    {
+      "matches": ["https://github.com/*/*/pull/*/files"],
+      "js": ["src/content.js"],
+      "run_at": "document_idle"
+    }
+  ]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -16,7 +16,8 @@
   },
   "permissions": [
     "activeTab",
-    "storage"
+    "storage",
+    "contextMenus"
   ],
   "host_permissions": [
     "https://*.github.com/*"

--- a/src/background.js
+++ b/src/background.js
@@ -3,10 +3,44 @@ const MANIFEST = chrome.runtime.getManifest();
 const BASE_QUERY = "?q=is%3Apr+is%3Aopen+";
 const HIDE_DEPENDABOT_QUERY = "-label%3Adependencies+";
 
-const onInstalled = async () => {
-  // TODO: Use this on options page
-  chrome.storage.sync.set({ version: `v${MANIFEST.version}` });
+const syncContextMenu = async () => {
+  const { autoPrune } = await chrome.storage.sync.get("autoPrune");
+  chrome.contextMenus.update("auto-prune-toggle", {
+    title: autoPrune
+      ? "✓ Auto-mark test files as viewed"
+      : "Auto-mark test files as viewed",
+  });
 };
+
+const onInstalled = async () => {
+  chrome.storage.sync.set({ version: `v${MANIFEST.version}` });
+
+  // Create the context menu for auto-prune toggle
+  chrome.contextMenus.removeAll();
+  chrome.contextMenus.create({
+    id: "auto-prune-toggle",
+    title: "Auto-mark test files as viewed",
+    contexts: ["action"],
+  });
+
+  // Set default if not already set
+  const { autoPrune } = await chrome.storage.sync.get("autoPrune");
+  if (autoPrune === undefined) {
+    await chrome.storage.sync.set({ autoPrune: true });
+  }
+
+  await syncContextMenu();
+};
+
+// Listen for context menu clicks to toggle auto-prune
+chrome.contextMenus.onClicked.addListener(async (info) => {
+  if (info.menuItemId === "auto-prune-toggle") {
+    const { autoPrune } = await chrome.storage.sync.get("autoPrune");
+    const newVal = !autoPrune;
+    await chrome.storage.sync.set({ autoPrune: newVal });
+    await syncContextMenu();
+  }
+});
 
 const getStateString = (state) => {
   return state ? "on" : "off";
@@ -89,3 +123,6 @@ chrome.tabs.onUpdated.addListener(async (_tabId, changeInfo, tab) => {
 });
 
 chrome.runtime.onInstalled.addListener(onInstalled);
+
+// Sync the context menu title when the service worker starts
+chrome.runtime.onStartup.addListener(syncContextMenu);

--- a/src/background.js
+++ b/src/background.js
@@ -104,6 +104,10 @@ const prunePullRequests = async (tab, shouldPrune = false) => {
 
 // CHROME LISTENERS
 chrome.action.onClicked.addListener(async (tab) => {
+  // Only ever touch the URL of the PR list page; leave every other page alone.
+  const { host, pathname } = new URL(tab.url);
+  if (!shouldExecuteOnTab(host, pathname)) return;
+
   const state = await getActiveTabState();
   prunePullRequests(tab, state);
   const newState = !state;

--- a/src/background.js
+++ b/src/background.js
@@ -106,7 +106,9 @@ const prunePullRequests = async (tab, shouldPrune = false) => {
 chrome.action.onClicked.addListener(async (tab) => {
   // Only ever touch the URL of the PR list page; leave every other page alone.
   const { host, pathname } = new URL(tab.url);
-  if (!shouldExecuteOnTab(host, pathname)) return;
+  if (!shouldExecuteOnTab(host, pathname)) {
+    return;
+  }
 
   const state = await getActiveTabState();
   prunePullRequests(tab, state);

--- a/src/content.js
+++ b/src/content.js
@@ -1,16 +1,26 @@
 /**
- * PruneR – Auto-mark test files as "Viewed" on GitHub PR file pages.
+ * PruneR – Auto-mark test files as "Viewed" on GitHub PR diff pages.
  *
- * When a PR's "Files changed" tab is loaded, any file whose path matches a
- * test-file pattern gets its "Viewed" checkbox automatically checked so it
- * stops being noise in your review queue.
+ * When a PR's diff is loaded, any file whose path matches a test-file pattern
+ * gets its "Viewed" control automatically toggled on so it stops being noise
+ * in your review queue.
  *
- * Supports both the newer file-tree sidebar and the classic diff file headers.
+ * GitHub ships two diff experiences and PruneR supports both:
+ *   • New React UI ("/pull/N/changes"): a <button aria-label="Not Viewed">.
+ *   • Classic UI  ("/pull/N/files"):    an <input type="checkbox" name="viewed">.
+ *
+ * The content script loads on every "/pull/*" page (the pages navigate
+ * client-side, so we can't scope tightly to the diff URL) and a
+ * MutationObserver re-runs as diffs stream in or the user switches tabs.
  * Checks the `autoPrune` storage flag so users can toggle the feature on/off
  * via the extension's context menu (right-click the toolbar icon).
  */
 
 const STORAGE_KEY = "autoPrune";
+
+// Marks a control we've already handled so the MutationObserver doesn't
+// re-toggle it (clicking the new button is a toggle, not a set).
+const PROCESSED_ATTR = "data-pruner-marked";
 
 const TEST_FILE_PATTERNS = [
   /\.test\.(ts|tsx|js|jsx|mjs|cjs)$/,
@@ -32,57 +42,52 @@ const TEST_FILE_PATTERNS = [
 const isTestFile = (filePath) =>
   TEST_FILE_PATTERNS.some((pattern) => pattern.test(filePath));
 
+// GitHub pads file-path links with bidirectional/zero-width control chars so
+// the truncated middle renders nicely. Strip them before pattern matching.
+const cleanPath = (text) =>
+  (text || "").replace(/[‎‏‪-‮⁦-⁩]/g, "").trim();
+
 /**
  * Try to extract a file path from a DOM element that contains a "Viewed"
- * checkbox. Returns null if no path can be found.
- *
- * Strategies (from most to least specific):
- * 1. data-path or data-file-header-path on the parent file-header element
- * 2. title attribute on the closest anchor or span
- * 3. text content of the file-info / file-info-text element nearby
- * 4. aria-label on the checkbox itself
- * 5. text content of the closest anchor or span
+ * control (either the new button or the classic checkbox). Returns null if
+ * no path can be found.
  */
-const getFilePath = (checkbox) => {
-  // Walk up to find the containing file-header or file-tree-list-item
-  const container =
-    checkbox.closest(
-      '[data-file-header-path], [data-path], [data-testid="file-tree-list-item"], .file-header'
-    ) || checkbox.parentElement;
+const getFilePath = (control) => {
+  // New React UI: the diff header wraps the control and a link to the file
+  // anchor whose text is the full path.
+  const headerWrapper = control.closest("[data-diff-header-wrapper]");
+  if (headerWrapper) {
+    const anchor = headerWrapper.querySelector('a[href^="#diff-"]');
+    const path = cleanPath(anchor?.textContent);
+    if (path) return path;
+  }
 
-  // Strategy 1: data attributes on the header
+  // Classic UI: walk up to the file header / file-tree item.
+  const container =
+    control.closest(
+      '[data-file-header-path], [data-path], [data-testid="file-tree-list-item"], .file-header'
+    ) || control.parentElement;
+
   if (container) {
     const dataPath =
       container.getAttribute("data-file-header-path") ||
       container.getAttribute("data-path");
     if (dataPath) return dataPath;
-  }
 
-  // Strategy 2: title attribute on an anchor or span inside the container
-  if (container) {
     const titledEl = container.querySelector("a[title], span[title]");
-    if (titledEl?.getAttribute("title")) {
-      return titledEl.getAttribute("title");
-    }
-  }
+    if (titledEl?.getAttribute("title")) return titledEl.getAttribute("title");
 
-  // Strategy 3: file-info-text content
-  if (container) {
     const infoEl = container.querySelector(
       ".file-info-text, [data-file-info-text]"
     );
     if (infoEl?.textContent?.trim()) return infoEl.textContent.trim();
   }
 
-  // Strategy 4: aria-label on the checkbox
-  const ariaLabel = checkbox.getAttribute("aria-label");
-  if (ariaLabel) {
-    // Often in the form "Viewed: path/to/file.ts"
-    const match = ariaLabel.match(/Viewed:\s*(.+)/i);
-    if (match) return match[1].trim();
-  }
+  // aria-label on the checkbox is often "Viewed: path/to/file.ts".
+  const ariaLabel = control.getAttribute("aria-label");
+  const match = ariaLabel?.match(/Viewed:\s*(.+)/i);
+  if (match) return match[1].trim();
 
-  // Strategy 5: text content of the closest link or titled element
   if (container) {
     const link = container.querySelector("a");
     if (link?.textContent?.trim()) return link.textContent.trim();
@@ -92,47 +97,72 @@ const getFilePath = (checkbox) => {
 };
 
 /**
+ * Collect the unmarked "Viewed" controls on the page from both UIs, each
+ * paired with the action that marks it seen.
+ */
+const getViewedControls = () => {
+  const controls = [];
+
+  // New UI: button that is currently "Not Viewed" (aria-pressed=false).
+  document
+    .querySelectorAll(
+      'button[aria-pressed="false"][aria-label="Not Viewed"]:not([' +
+        PROCESSED_ATTR +
+        "])"
+    )
+    .forEach((button) => controls.push({ el: button, mark: () => button.click() }));
+
+  // Classic UI: unchecked checkbox — set it and let React know via events.
+  document
+    .querySelectorAll(
+      'input[type="checkbox"][name="viewed"]:not(:checked):not([' +
+        PROCESSED_ATTR +
+        "])"
+    )
+    .forEach((checkbox) =>
+      controls.push({
+        el: checkbox,
+        mark: () => {
+          checkbox.checked = true;
+          checkbox.dispatchEvent(
+            new Event("input", { bubbles: true, cancelable: true })
+          );
+          checkbox.dispatchEvent(
+            new Event("change", { bubbles: true, cancelable: true })
+          );
+        },
+      })
+    );
+
+  return controls;
+};
+
+/**
  * Mark all test files as "Viewed" on the current page.
- * Returns true if any checkboxes were found (even if none were test files).
+ * Returns true if any file was marked.
  */
 const markTestFilesSeen = async () => {
-  // Check the auto-prune flag
   const { autoPrune } = await chrome.storage.sync.get(STORAGE_KEY);
   if (autoPrune === false) return false;
 
-  // Get ALL "Viewed" checkboxes on the page — covers both the file tree
-  // sidebar and the classic diff file headers.
-  const checkboxes = document.querySelectorAll(
-    'input[type="checkbox"][name="viewed"]:not(:checked)'
-  );
-  if (!checkboxes.length) return false;
-
   let marked = false;
-  checkboxes.forEach((checkbox) => {
-    const filePath = getFilePath(checkbox);
-    if (!filePath || !isTestFile(filePath)) return;
+  for (const { el, mark } of getViewedControls()) {
+    const filePath = getFilePath(el);
+    if (!filePath || !isTestFile(filePath)) continue;
 
-    // Check the checkbox
-    checkbox.checked = true;
-
-    // GitHub uses React, so we need to dispatch native events to let
-    // React know the state changed.
-    checkbox.dispatchEvent(
-      new Event("input", { bubbles: true, cancelable: true })
-    );
-    checkbox.dispatchEvent(
-      new Event("change", { bubbles: true, cancelable: true })
-    );
-
+    // Guard against the observer re-toggling before GitHub updates the
+    // control's state asynchronously.
+    el.setAttribute(PROCESSED_ATTR, "1");
+    mark();
     marked = true;
-  });
+  }
 
   return marked;
 };
 
 /**
- * Set up a MutationObserver that watches for new "Viewed" checkboxes
- * being added to the page (e.g. when expanding diffs or navigating).
+ * Set up a MutationObserver that watches for new "Viewed" controls being
+ * added to the page (diffs stream in lazily and tabs navigate client-side).
  */
 const setupObserver = () => {
   const observer = new MutationObserver(() => {
@@ -144,7 +174,7 @@ const setupObserver = () => {
     subtree: true,
   });
 
-  // Also run once immediately in case the DOM is already ready
+  // Also run once immediately in case the DOM is already ready.
   markTestFilesSeen();
 };
 

--- a/src/content.js
+++ b/src/content.js
@@ -59,7 +59,9 @@ const getFilePath = (control) => {
   if (headerWrapper) {
     const anchor = headerWrapper.querySelector('a[href^="#diff-"]');
     const path = cleanPath(anchor?.textContent);
-    if (path) return path;
+    if (path) {
+      return path;
+    }
   }
 
   // Classic UI: walk up to the file header / file-tree item.
@@ -72,25 +74,35 @@ const getFilePath = (control) => {
     const dataPath =
       container.getAttribute("data-file-header-path") ||
       container.getAttribute("data-path");
-    if (dataPath) return dataPath;
+    if (dataPath) {
+      return dataPath;
+    }
 
     const titledEl = container.querySelector("a[title], span[title]");
-    if (titledEl?.getAttribute("title")) return titledEl.getAttribute("title");
+    if (titledEl?.getAttribute("title")) {
+      return titledEl.getAttribute("title");
+    }
 
     const infoEl = container.querySelector(
       ".file-info-text, [data-file-info-text]"
     );
-    if (infoEl?.textContent?.trim()) return infoEl.textContent.trim();
+    if (infoEl?.textContent?.trim()) {
+      return infoEl.textContent.trim();
+    }
   }
 
   // aria-label on the checkbox is often "Viewed: path/to/file.ts".
   const ariaLabel = control.getAttribute("aria-label");
   const match = ariaLabel?.match(/Viewed:\s*(.+)/i);
-  if (match) return match[1].trim();
+  if (match) {
+    return match[1].trim();
+  }
 
   if (container) {
     const link = container.querySelector("a");
-    if (link?.textContent?.trim()) return link.textContent.trim();
+    if (link?.textContent?.trim()) {
+      return link.textContent.trim();
+    }
   }
 
   return null;
@@ -143,12 +155,16 @@ const getViewedControls = () => {
  */
 const markTestFilesSeen = async () => {
   const { autoPrune } = await chrome.storage.sync.get(STORAGE_KEY);
-  if (autoPrune === false) return false;
+  if (autoPrune === false) {
+    return false;
+  }
 
   let marked = false;
   for (const { el, mark } of getViewedControls()) {
     const filePath = getFilePath(el);
-    if (!filePath || !isTestFile(filePath)) continue;
+    if (!filePath || !isTestFile(filePath)) {
+      continue;
+    }
 
     // Guard against the observer re-toggling before GitHub updates the
     // control's state asynchronously.

--- a/src/content.js
+++ b/src/content.js
@@ -1,0 +1,97 @@
+/**
+ * PruneR – Auto-mark test files as "Viewed" on GitHub PR file pages.
+ *
+ * When a PR file tree is loaded, any file whose path matches a test-file
+ * pattern is automatically checked as "Viewed" so it stops being noise in
+ * the review queue. The checkbox is toggled silently — no click events are
+ * fired, just the underlying input state and React's data attributes.
+ */
+
+const TEST_FILE_PATTERNS = [
+  /\.test\.(ts|tsx|js|jsx|mjs|cjs)$/,
+  /\.spec\.(ts|tsx|js|jsx|mjs|cjs)$/,
+  /\/__tests__\//,
+  /\/test\//,
+  /\/tests\//,
+  /\/__mocks__\//,
+  /\/__fixtures__\//,
+  /\/__snapshots__\//,
+  /\.snap$/,
+  /\/storybook\//i,
+  /\.stories\.(ts|tsx|js|jsx)$/,
+  /\/mocks?\//i,
+  /\/fixtures?\//i,
+  /\/testing\//i,
+];
+
+const isTestFile = (filePath) =>
+  TEST_FILE_PATTERNS.some((pattern) => pattern.test(filePath));
+
+/**
+ * Wait for the file tree to be present and then mark test files as viewed.
+ * Uses a MutationObserver so newly loaded files (e.g., when expanding diffs)
+ * are also handled.
+ */
+const markTestFilesSeen = () => {
+  const fileTree = document.querySelector('[data-file-tree]');
+  if (!fileTree) return false;
+
+  const fileRows = fileTree.querySelectorAll(
+    '[data-file-tree-list] [data-testid="file-tree-list-item"]'
+  );
+
+  fileRows.forEach((row) => {
+    // Get the file path from the anchor title or text content
+    const link = row.querySelector('a[title], span[title]');
+    const filePath = link?.getAttribute('title') || link?.textContent || '';
+    if (!filePath || !isTestFile(filePath)) return;
+
+    // Find the "Viewed" checkbox inside this row
+    const checkbox = row.querySelector(
+      'input[type="checkbox"][name="viewed"]'
+    );
+    if (!checkbox || checkbox.checked) return;
+
+    // Check the checkbox
+    checkbox.checked = true;
+
+    // GitHub uses React, so we need to dispatch an input event to
+    // let React know the checkbox state changed.
+    checkbox.dispatchEvent(
+      new Event('input', { bubbles: true, cancelable: true })
+    );
+    checkbox.dispatchEvent(
+      new Event('change', { bubbles: true, cancelable: true })
+    );
+  });
+
+  return true;
+};
+
+/**
+ * Observe the PR files page and mark test files as viewed whenever the
+ * file tree is updated (initial load, expanding files, navigating diffs).
+ */
+const setupObserver = () => {
+  // Watch for the file tree to appear (SPA navigation)
+  const observer = new MutationObserver(() => {
+    if (markTestFilesSeen()) {
+      // File tree found and processed — we can keep observing for dynamic updates
+    }
+  });
+
+  observer.observe(document.body, {
+    childList: true,
+    subtree: true,
+  });
+
+  // Also run once immediately in case the DOM is already ready
+  markTestFilesSeen();
+};
+
+// Kick off as soon as the DOM is ready
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', setupObserver);
+} else {
+  setupObserver();
+}

--- a/src/content.js
+++ b/src/content.js
@@ -1,11 +1,16 @@
 /**
  * PruneR – Auto-mark test files as "Viewed" on GitHub PR file pages.
  *
- * When a PR file tree is loaded, any file whose path matches a test-file
- * pattern is automatically checked as "Viewed" so it stops being noise in
- * the review queue. The checkbox is toggled silently — no click events are
- * fired, just the underlying input state and React's data attributes.
+ * When a PR's "Files changed" tab is loaded, any file whose path matches a
+ * test-file pattern gets its "Viewed" checkbox automatically checked so it
+ * stops being noise in your review queue.
+ *
+ * Supports both the newer file-tree sidebar and the classic diff file headers.
+ * Checks the `autoPrune` storage flag so users can toggle the feature on/off
+ * via the extension's context menu (right-click the toolbar icon).
  */
+
+const STORAGE_KEY = "autoPrune";
 
 const TEST_FILE_PATTERNS = [
   /\.test\.(ts|tsx|js|jsx|mjs|cjs)$/,
@@ -28,56 +33,110 @@ const isTestFile = (filePath) =>
   TEST_FILE_PATTERNS.some((pattern) => pattern.test(filePath));
 
 /**
- * Wait for the file tree to be present and then mark test files as viewed.
- * Uses a MutationObserver so newly loaded files (e.g., when expanding diffs)
- * are also handled.
+ * Try to extract a file path from a DOM element that contains a "Viewed"
+ * checkbox. Returns null if no path can be found.
+ *
+ * Strategies (from most to least specific):
+ * 1. data-path or data-file-header-path on the parent file-header element
+ * 2. title attribute on the closest anchor or span
+ * 3. text content of the file-info / file-info-text element nearby
+ * 4. aria-label on the checkbox itself
+ * 5. text content of the closest anchor or span
  */
-const markTestFilesSeen = () => {
-  const fileTree = document.querySelector('[data-file-tree]');
-  if (!fileTree) return false;
+const getFilePath = (checkbox) => {
+  // Walk up to find the containing file-header or file-tree-list-item
+  const container =
+    checkbox.closest(
+      '[data-file-header-path], [data-path], [data-testid="file-tree-list-item"], .file-header'
+    ) || checkbox.parentElement;
 
-  const fileRows = fileTree.querySelectorAll(
-    '[data-file-tree-list] [data-testid="file-tree-list-item"]'
-  );
+  // Strategy 1: data attributes on the header
+  if (container) {
+    const dataPath =
+      container.getAttribute("data-file-header-path") ||
+      container.getAttribute("data-path");
+    if (dataPath) return dataPath;
+  }
 
-  fileRows.forEach((row) => {
-    // Get the file path from the anchor title or text content
-    const link = row.querySelector('a[title], span[title]');
-    const filePath = link?.getAttribute('title') || link?.textContent || '';
-    if (!filePath || !isTestFile(filePath)) return;
+  // Strategy 2: title attribute on an anchor or span inside the container
+  if (container) {
+    const titledEl = container.querySelector("a[title], span[title]");
+    if (titledEl?.getAttribute("title")) {
+      return titledEl.getAttribute("title");
+    }
+  }
 
-    // Find the "Viewed" checkbox inside this row
-    const checkbox = row.querySelector(
-      'input[type="checkbox"][name="viewed"]'
+  // Strategy 3: file-info-text content
+  if (container) {
+    const infoEl = container.querySelector(
+      ".file-info-text, [data-file-info-text]"
     );
-    if (!checkbox || checkbox.checked) return;
+    if (infoEl?.textContent?.trim()) return infoEl.textContent.trim();
+  }
+
+  // Strategy 4: aria-label on the checkbox
+  const ariaLabel = checkbox.getAttribute("aria-label");
+  if (ariaLabel) {
+    // Often in the form "Viewed: path/to/file.ts"
+    const match = ariaLabel.match(/Viewed:\s*(.+)/i);
+    if (match) return match[1].trim();
+  }
+
+  // Strategy 5: text content of the closest link or titled element
+  if (container) {
+    const link = container.querySelector("a");
+    if (link?.textContent?.trim()) return link.textContent.trim();
+  }
+
+  return null;
+};
+
+/**
+ * Mark all test files as "Viewed" on the current page.
+ * Returns true if any checkboxes were found (even if none were test files).
+ */
+const markTestFilesSeen = async () => {
+  // Check the auto-prune flag
+  const { autoPrune } = await chrome.storage.sync.get(STORAGE_KEY);
+  if (autoPrune === false) return false;
+
+  // Get ALL "Viewed" checkboxes on the page — covers both the file tree
+  // sidebar and the classic diff file headers.
+  const checkboxes = document.querySelectorAll(
+    'input[type="checkbox"][name="viewed"]:not(:checked)'
+  );
+  if (!checkboxes.length) return false;
+
+  let marked = false;
+  checkboxes.forEach((checkbox) => {
+    const filePath = getFilePath(checkbox);
+    if (!filePath || !isTestFile(filePath)) return;
 
     // Check the checkbox
     checkbox.checked = true;
 
-    // GitHub uses React, so we need to dispatch an input event to
-    // let React know the checkbox state changed.
+    // GitHub uses React, so we need to dispatch native events to let
+    // React know the state changed.
     checkbox.dispatchEvent(
-      new Event('input', { bubbles: true, cancelable: true })
+      new Event("input", { bubbles: true, cancelable: true })
     );
     checkbox.dispatchEvent(
-      new Event('change', { bubbles: true, cancelable: true })
+      new Event("change", { bubbles: true, cancelable: true })
     );
+
+    marked = true;
   });
 
-  return true;
+  return marked;
 };
 
 /**
- * Observe the PR files page and mark test files as viewed whenever the
- * file tree is updated (initial load, expanding files, navigating diffs).
+ * Set up a MutationObserver that watches for new "Viewed" checkboxes
+ * being added to the page (e.g. when expanding diffs or navigating).
  */
 const setupObserver = () => {
-  // Watch for the file tree to appear (SPA navigation)
   const observer = new MutationObserver(() => {
-    if (markTestFilesSeen()) {
-      // File tree found and processed — we can keep observing for dynamic updates
-    }
+    markTestFilesSeen();
   });
 
   observer.observe(document.body, {
@@ -90,8 +149,8 @@ const setupObserver = () => {
 };
 
 // Kick off as soon as the DOM is ready
-if (document.readyState === 'loading') {
-  document.addEventListener('DOMContentLoaded', setupObserver);
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", setupObserver);
 } else {
   setupObserver();
 }


### PR DESCRIPTION
## What's new in PruneR v2 ✨

### 👁️ Auto-mark test files as viewed
When you open a PR's **Files changed** tab, PruneR now automatically checks the "Viewed" checkbox on test/config/mock/fixture files — so they collapse out of your review flow and you can focus on the real logic changes.

✅ **Toggle on/off:** Right-click the PruneR icon → "Auto-mark test files as viewed" (checkmark ✓ means active)

🐛 **Fixed:** `.spec.ts` (and other extension combos) now correctly detected by scanning both the file-tree sidebar and diff file headers for checkboxes.

### 👷 Verified publish workflow
New GitHub Actions workflow (mirroring cherry's pattern) that:
- Runs on every published release
- Validates manifest version matches the tag
- Builds & signs the ZIP with Verified CRX key
- Publishes to Chrome Web Store
- Attaches the unsigned ZIP to the release

### 📦 Latest release ZIP install
Added download-from-latest-release instructions for folks who want the extension before it clears Web Store review.

---

### Files changed
| File | Change |
|---|---|
| `manifest.json` | Bump v0.0.4 → v0.1.0, add `content_scripts` + `contextMenus` permission |
| `src/content.js` | **New** — auto-marks test files as viewed, respects autoPrune flag, scans all checkbox locations |
| `src/background.js` | Added context menu for toggling auto-prune on/off |
| `.github/workflows/publish.yml` | **New** — verified CWS publish workflow |
| `README.md` | Rewritten with v2 docs, feature table, toggle instructions, release install, publishing guide |