### PR TITLE
feat: add options page and show hidden dependency PR count

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+      - run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .DS_Store
 icon/.DS_Store
+node_modules/
+coverage/

--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ Click the PruneR icon in your toolbar while you're on a GitHub PR list page
 (`https://github.com/org/repo/pulls`). It adds `-label:dependencies` to the URL,
 hiding all dependabot / dependency PRs in one click. Click again to show them.
 
+While the filter is active, the icon shows a **badge with the number of open
+dependency PRs currently hidden**, so you always know what's being pruned.
+(The count comes from the GitHub Search API and may not appear on private
+repositories.)
+
 ### 2. Auto-mark test files as viewed
 
 When you open a PR's **Files changed** tab (`/pull/*/files`), PruneR
@@ -45,6 +50,10 @@ so they collapse out of your review flow. Focus on the actual logic changes.
 > **Toggle on/off:** Right-click the PruneR icon in your toolbar and select
 > "Auto-mark test files as viewed" to enable or disable this feature.
 > A checkmark ✓ means it's active.
+>
+> Prefer a UI? Open **PruneR Options** — right-click the toolbar icon and pick
+> "PruneR Options", or find it under `chrome://extensions/` → PruneR → Details →
+> Extension options.
 
 ---
 

--- a/manifest.json
+++ b/manifest.json
@@ -33,7 +33,7 @@
   "content_scripts": [
     {
       "matches": ["https://github.com/*/*/pull/*"],
-      "js": ["src/content.js"],
+      "js": ["src/prune.js", "src/content.js"],
       "run_at": "document_idle"
     }
   ]

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "PruneR",
   "author": "Aashutosh Rathi",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "manifest_version": 3,
   "description": "Clear PR clutter and auto-dim test files so you focus on what matters",
   "icons": {
@@ -14,13 +14,18 @@
     "default_icon": "icons/icon19.png",
     "default_title": "PruneR"
   },
+  "options_ui": {
+    "page": "src/options.html",
+    "open_in_tab": true
+  },
   "permissions": [
     "activeTab",
     "storage",
     "contextMenus"
   ],
   "host_permissions": [
-    "https://*.github.com/*"
+    "https://*.github.com/*",
+    "https://api.github.com/*"
   ],
   "background": {
     "service_worker": "src/background.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,816 @@
+{
+  "name": "pruner",
+  "version": "0.2.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "pruner",
+      "version": "0.2.0",
+      "license": "MIT",
+      "devDependencies": {
+        "jsdom": "^25.0.1"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "25.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
+      "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.1.0",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.24",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.24.tgz",
+      "integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "pruner",
+  "version": "0.2.0",
+  "description": "Clear PR clutter and auto-dim test files so you focus on what matters",
+  "private": true,
+  "license": "MIT",
+  "scripts": {
+    "test": "node --test"
+  },
+  "devDependencies": {
+    "jsdom": "^25.0.1"
+  }
+}

--- a/src/background.js
+++ b/src/background.js
@@ -82,15 +82,36 @@ const getActiveTabState = async () => {
     currentWindow: true,
   });
 
-  if (!activeTab?.url) {
-    return false;
-  }
+  return activeTab?.url ? stateForUrl(activeTab.url) : false;
+};
 
-  const { search, host, pathname } = new URL(activeTab.url);
+/*
+  Whether a GitHub URL currently has the dependency filter applied.
+*/
+const stateForUrl = (url) => {
+  if (!url) return false;
+  const { search, host, pathname } = new URL(url);
   if (shouldExecuteOnTab(host, pathname)) {
     return search.includes(HIDE_DEPENDABOT_QUERY);
   }
   return false;
+};
+
+/*
+  Recomputes the hidden dependency PR count for the given tab and syncs the
+  badge/icon with its filter state. Re-fetching on every tab switch/navigation
+  keeps the badge accurate for the repo that is actually active.
+*/
+const refreshBadge = async (url) => {
+  const state = stateForUrl(url);
+  let hiddenPRCount = null;
+  if (state) {
+    const repo = getRepoFromUrl(url);
+    if (repo) {
+      hiddenPRCount = await getHiddenPRCount(repo);
+    }
+  }
+  await syncState(state, hiddenPRCount);
 };
 
 /*
@@ -142,12 +163,12 @@ const syncBadge = async () => {
   Updates the state of current tab in storage and icon
 */
 const syncState = async (newState, hiddenPRCount = null) => {
-  chrome.storage.sync.set({ state: newState });
-  if (hiddenPRCount !== null) {
-    chrome.storage.sync.set({ hiddenPRCount });
-  }
+  // Write both keys together and await so `syncBadge()` never reads stale
+  // values. Writing `hiddenPRCount` unconditionally also clears a previously
+  // fetched count when the filter is turned off or the fetch fails.
+  await chrome.storage.sync.set({ state: newState, hiddenPRCount });
   const iconPath = `../icons/${getStateString(newState)}-icon.png`;
-  chrome.action.setIcon({
+  await chrome.action.setIcon({
     path: iconPath,
   });
   await syncBadge();
@@ -186,18 +207,20 @@ chrome.action.onClicked.addListener(async (tab) => {
       hiddenPRCount = await getHiddenPRCount(repo);
     }
   }
-  syncState(newState, hiddenPRCount);
+  await syncState(newState, hiddenPRCount);
 });
 
 chrome.tabs.onActivated.addListener(async () => {
-  const state = await getActiveTabState();
-  syncState(state);
+  const [activeTab] = await chrome.tabs.query({
+    active: true,
+    currentWindow: true,
+  });
+  await refreshBadge(activeTab?.url);
 });
 
 chrome.tabs.onUpdated.addListener(async (_tabId, changeInfo, tab) => {
   if (changeInfo.status === "complete" && tab?.active) {
-    const state = await getActiveTabState();
-    syncState(state);
+    await refreshBadge(tab.url);
   }
 });
 

--- a/src/background.js
+++ b/src/background.js
@@ -2,6 +2,7 @@ const MANIFEST = chrome.runtime.getManifest();
 
 const BASE_QUERY = "?q=is%3Apr+is%3Aopen+";
 const HIDE_DEPENDABOT_QUERY = "-label%3Adependencies+";
+const SEARCH_API_URL = "https://api.github.com/search/issues";
 
 const syncContextMenu = async () => {
   const { autoPrune } = await chrome.storage.sync.get("autoPrune");
@@ -15,11 +16,16 @@ const syncContextMenu = async () => {
 const onInstalled = async () => {
   chrome.storage.sync.set({ version: `v${MANIFEST.version}` });
 
-  // Create the context menu for auto-prune toggle
+  // Create the context menu for auto-prune toggle and options
   chrome.contextMenus.removeAll();
   chrome.contextMenus.create({
     id: "auto-prune-toggle",
     title: "Auto-mark test files as viewed",
+    contexts: ["action"],
+  });
+  chrome.contextMenus.create({
+    id: "open-options",
+    title: "PruneR Options",
     contexts: ["action"],
   });
 
@@ -32,13 +38,23 @@ const onInstalled = async () => {
   await syncContextMenu();
 };
 
-// Listen for context menu clicks to toggle auto-prune
+// Listen for context menu clicks
 chrome.contextMenus.onClicked.addListener(async (info) => {
   if (info.menuItemId === "auto-prune-toggle") {
     const { autoPrune } = await chrome.storage.sync.get("autoPrune");
     const newVal = !autoPrune;
     await chrome.storage.sync.set({ autoPrune: newVal });
     await syncContextMenu();
+  } else if (info.menuItemId === "open-options") {
+    chrome.runtime.openOptionsPage();
+  }
+});
+
+// Keep the context menu title in sync when the option is changed on the
+// options page instead of the context menu.
+chrome.storage.onChanged.addListener((changes, area) => {
+  if (area === "sync" && "autoPrune" in changes) {
+    syncContextMenu();
   }
 });
 
@@ -57,7 +73,7 @@ const getAdditionQuery = (search) => {
   return HIDE_DEPENDABOT_QUERY;
 };
 
-/* 
+/*
   Returns the state of the current tab
 */
 const getActiveTabState = async () => {
@@ -77,18 +93,67 @@ const getActiveTabState = async () => {
   return false;
 };
 
-/* 
+/*
+  Extracts the "owner/repo" pair out of a github.com URL.
+*/
+const getRepoFromUrl = (url) => {
+  const { host, pathname } = new URL(url);
+  if (host !== "github.com") {
+    return null;
+  }
+  const match = pathname.match(/^\/([^/]+)\/([^/]+)(?:\/|$)/);
+  return match ? `${match[1]}/${match[2]}` : null;
+};
+
+/*
+  Asks the GitHub Search API how many open PRs carry the `dependencies`
+  label (the ones PruneR hides). Falls back to null when the request fails,
+  e.g. on private repositories or transient network errors.
+*/
+const getHiddenPRCount = async (repo) => {
+  try {
+    const query = `repo:${repo}%20is:pr%20is:open%20label:dependencies`;
+    const res = await fetch(`${SEARCH_API_URL}?q=${query}&per_page=1`);
+    if (!res.ok) {
+      return null;
+    }
+    const { total_count } = await res.json();
+    return typeof total_count === "number" ? total_count : null;
+  } catch {
+    return null;
+  }
+};
+
+/*
+  Shows the number of hidden dependabot PRs as a badge on the toolbar icon
+  whenever the dependabot filter is active on the current tab.
+*/
+const syncBadge = async () => {
+  const { state, hiddenPRCount } = await chrome.storage.sync.get([
+    "state",
+    "hiddenPRCount",
+  ]);
+  const show = state && hiddenPRCount !== undefined && hiddenPRCount !== null;
+  chrome.action.setBadgeBackgroundColor({ color: "#6e7781" });
+  chrome.action.setBadgeText({ text: show ? String(hiddenPRCount) : "" });
+};
+
+/*
   Updates the state of current tab in storage and icon
 */
-const syncState = async (newState) => {
+const syncState = async (newState, hiddenPRCount = null) => {
   chrome.storage.sync.set({ state: newState });
+  if (hiddenPRCount !== null) {
+    chrome.storage.sync.set({ hiddenPRCount });
+  }
   const iconPath = `../icons/${getStateString(newState)}-icon.png`;
   chrome.action.setIcon({
     path: iconPath,
   });
+  await syncBadge();
 };
 
-/* 
+/*
   Applies or removes the query on the current tab
 */
 const prunePullRequests = async (tab, shouldPrune = false) => {
@@ -113,7 +178,15 @@ chrome.action.onClicked.addListener(async (tab) => {
   const state = await getActiveTabState();
   prunePullRequests(tab, state);
   const newState = !state;
-  syncState(newState);
+
+  let hiddenPRCount = null;
+  if (newState) {
+    const repo = getRepoFromUrl(tab.url);
+    if (repo) {
+      hiddenPRCount = await getHiddenPRCount(repo);
+    }
+  }
+  syncState(newState, hiddenPRCount);
 });
 
 chrome.tabs.onActivated.addListener(async () => {

--- a/src/content.js
+++ b/src/content.js
@@ -5,198 +5,76 @@
  * gets its "Viewed" control automatically toggled on so it stops being noise
  * in your review queue.
  *
- * GitHub ships two diff experiences and PruneR supports both:
- *   • New React UI ("/pull/N/changes"): a <button aria-label="Not Viewed">.
- *   • Classic UI  ("/pull/N/files"):    an <input type="checkbox" name="viewed">.
+ * GitHub renders diffs lazily and (for large PRs) virtualizes them, so files
+ * stream into the DOM as you scroll. Instead of scanning the page once and
+ * hoping, a MutationObserver re-runs a scan every time the DOM changes and
+ * marks a control the moment its file is in the DOM, whether it mounted with
+ * the page or appeared a second ago. Once a path has been handled it is kept
+ * in a session set, so a virtualized row that gets unmounted and remounted
+ * (losing its DOM state) can never be clicked a second time and toggled back.
  *
- * The content script loads on every "/pull/*" page (the pages navigate
- * client-side, so we can't scope tightly to the diff URL) and a
- * MutationObserver re-runs as diffs stream in or the user switches tabs.
- * Checks the `autoPrune` storage flag so users can toggle the feature on/off
- * via the extension's context menu (right-click the toolbar icon).
+ * The heavy lifting (pattern matching, path resolution, state detection) lives
+ * in prune.js so it can be unit-tested; this file only wires it to the page.
  */
+"use strict";
 
 const STORAGE_KEY = "autoPrune";
 
-// Marks a control we've already handled so the MutationObserver doesn't
-// re-toggle it (clicking the new button is a toggle, not a set).
-const PROCESSED_ATTR = "data-pruner-marked";
+// Paths already marked this session — survives virtualized rows being torn
+// down and remounted, which would otherwise reset our attribute guard.
+const processedPaths = new Set();
 
-const TEST_FILE_PATTERNS = [
-  /\.test\.(ts|tsx|js|jsx|mjs|cjs)$/,
-  /\.spec\.(ts|tsx|js|jsx|mjs|cjs)$/,
-  /\/__tests__\//,
-  /\/test\//,
-  /\/tests\//,
-  /\/__mocks__\//,
-  /\/__fixtures__\//,
-  /\/__snapshots__\//,
-  /\.snap$/,
-  /\/storybook\//i,
-  /\.stories\.(ts|tsx|js|jsx)$/,
-  /\/mocks?\//i,
-  /\/fixtures?\//i,
-  /\/testing\//i,
-];
-
-const isTestFile = (filePath) =>
-  TEST_FILE_PATTERNS.some((pattern) => pattern.test(filePath));
-
-// GitHub pads file-path links with bidirectional/zero-width control chars so
-// the truncated middle renders nicely. Strip them before pattern matching.
-const cleanPath = (text) =>
-  (text || "").replace(/[‎‏‪-‮⁦-⁩]/g, "").trim();
+let scanTimer = null;
 
 /**
- * Try to extract a file path from a DOM element that contains a "Viewed"
- * control (either the new button or the classic checkbox). Returns null if
- * no path can be found.
+ * Mark all currently-in-the-DOM test files as "Viewed". Returns true if any
+ * file was marked.
  */
-const getFilePath = (control) => {
-  // New React UI: the diff header wraps the control and a link to the file
-  // anchor whose text is the full path.
-  const headerWrapper = control.closest("[data-diff-header-wrapper]");
-  if (headerWrapper) {
-    const anchor = headerWrapper.querySelector('a[href^="#diff-"]');
-    const path = cleanPath(anchor?.textContent);
-    if (path) {
-      return path;
-    }
-  }
-
-  // Classic UI: walk up to the file header / file-tree item.
-  const container =
-    control.closest(
-      '[data-file-header-path], [data-path], [data-testid="file-tree-list-item"], .file-header'
-    ) || control.parentElement;
-
-  if (container) {
-    const dataPath =
-      container.getAttribute("data-file-header-path") ||
-      container.getAttribute("data-path");
-    if (dataPath) {
-      return dataPath;
-    }
-
-    const titledEl = container.querySelector("a[title], span[title]");
-    if (titledEl?.getAttribute("title")) {
-      return titledEl.getAttribute("title");
-    }
-
-    const infoEl = container.querySelector(
-      ".file-info-text, [data-file-info-text]"
-    );
-    if (infoEl?.textContent?.trim()) {
-      return infoEl.textContent.trim();
-    }
-  }
-
-  // aria-label on the checkbox is often "Viewed: path/to/file.ts".
-  const ariaLabel = control.getAttribute("aria-label");
-  const match = ariaLabel?.match(/Viewed:\s*(.+)/i);
-  if (match) {
-    return match[1].trim();
-  }
-
-  if (container) {
-    const link = container.querySelector("a");
-    if (link?.textContent?.trim()) {
-      return link.textContent.trim();
-    }
-  }
-
-  return null;
-};
-
-/**
- * Collect the unmarked "Viewed" controls on the page from both UIs, each
- * paired with the action that marks it seen.
- */
-const getViewedControls = () => {
-  const controls = [];
-
-  // New UI: button that is currently "Not Viewed" (aria-pressed=false).
-  document
-    .querySelectorAll(
-      'button[aria-pressed="false"][aria-label="Not Viewed"]:not([' +
-        PROCESSED_ATTR +
-        "])"
-    )
-    .forEach((button) => controls.push({ el: button, mark: () => button.click() }));
-
-  // Classic UI: unchecked checkbox — set it and let React know via events.
-  document
-    .querySelectorAll(
-      'input[type="checkbox"][name="viewed"]:not(:checked):not([' +
-        PROCESSED_ATTR +
-        "])"
-    )
-    .forEach((checkbox) =>
-      controls.push({
-        el: checkbox,
-        mark: () => {
-          checkbox.checked = true;
-          checkbox.dispatchEvent(
-            new Event("input", { bubbles: true, cancelable: true })
-          );
-          checkbox.dispatchEvent(
-            new Event("change", { bubbles: true, cancelable: true })
-          );
-        },
-      })
-    );
-
-  return controls;
-};
-
-/**
- * Mark all test files as "Viewed" on the current page.
- * Returns true if any file was marked.
- */
-const markTestFilesSeen = async () => {
+const scan = async () => {
   const { autoPrune } = await chrome.storage.sync.get(STORAGE_KEY);
-  if (autoPrune === false) {
-    return false;
-  }
+  if (autoPrune === false) return false;
 
-  let marked = false;
-  for (const { el, mark } of getViewedControls()) {
-    const filePath = getFilePath(el);
-    if (!filePath || !isTestFile(filePath)) {
-      continue;
+  let marked = 0;
+  for (const action of window.PruneR.collectMarks(
+    document,
+    processedPaths
+  )) {
+    if (processedPaths.has(action.path)) continue;
+    if (action.container) {
+      action.container.setAttribute(window.PruneR.PROCESSED_ATTR, "1");
     }
-
-    // Guard against the observer re-toggling before GitHub updates the
-    // control's state asynchronously.
-    el.setAttribute(PROCESSED_ATTR, "1");
-    mark();
-    marked = true;
+    processedPaths.add(action.path);
+    action.mark();
+    marked++;
   }
-
-  return marked;
+  return marked > 0;
 };
 
 /**
- * Set up a MutationObserver that watches for new "Viewed" controls being
- * added to the page (diffs stream in lazily and tabs navigate client-side).
+ * Debounce scans: GitHub adds large DOM subtrees in single mutation batches
+ * and we don't want to rebuild the control list for every node of every batch.
  */
-const setupObserver = () => {
-  const observer = new MutationObserver(() => {
-    markTestFilesSeen();
-  });
-
-  observer.observe(document.body, {
-    childList: true,
-    subtree: true,
-  });
-
-  // Also run once immediately in case the DOM is already ready.
-  markTestFilesSeen();
+const scheduleScan = () => {
+  if (scanTimer !== null) return;
+  scanTimer = setTimeout(() => {
+    scanTimer = null;
+    scan().catch((err) => console.error("[PruneR]", err));
+  }, 150);
 };
 
-// Kick off as soon as the DOM is ready
+/**
+ * Kick off an immediate scan, then watch for new controls streaming in (tabs
+ * navigate client-side and diff rows mount lazily / as you scroll).
+ */
+const setup = () => {
+  scan().catch((err) => console.error("[PruneR]", err));
+
+  const observer = new MutationObserver(scheduleScan);
+  observer.observe(document.body, { childList: true, subtree: true });
+};
+
 if (document.readyState === "loading") {
-  document.addEventListener("DOMContentLoaded", setupObserver);
+  document.addEventListener("DOMContentLoaded", setup);
 } else {
-  setupObserver();
+  setup();
 }

--- a/src/content.js
+++ b/src/content.js
@@ -25,12 +25,56 @@ const STORAGE_KEY = "autoPrune";
 const processedPaths = new Set();
 
 let scanTimer = null;
+let observer = null;
+
+/**
+ * A content script keeps running after its extension is reloaded, updated, or
+ * disabled (common during development), but its `chrome.*` handles are now
+ * dead — any call throws "Extension context invalidated". `chrome.runtime.id`
+ * goes undefined at the same moment, so it's a cheap way to spot the orphan.
+ */
+const isExtensionContextValid = () => Boolean(chrome.runtime?.id);
+
+/**
+ * Stop all page activity. Called once the extension context is gone so we
+ * don't loop on a broken context for every DOM mutation.
+ */
+const teardown = () => {
+  if (observer) {
+    observer.disconnect();
+    observer = null;
+  }
+  if (scanTimer !== null) {
+    clearTimeout(scanTimer);
+    scanTimer = null;
+  }
+};
+
+/**
+ * A scan may fail because the extension was reloaded out from under us; that's
+ * expected, so tear down quietly instead of spamming the console. Anything
+ * else is a real bug and gets logged.
+ */
+const handleScanError = (err) => {
+  if (
+    !isExtensionContextValid() ||
+    /Extension context invalidated/.test(err?.message)
+  ) {
+    teardown();
+    return;
+  }
+  console.error("[PruneR]", err);
+};
 
 /**
  * Mark all currently-in-the-DOM test files as "Viewed". Returns true if any
  * file was marked.
  */
 const scan = async () => {
+  if (!isExtensionContextValid()) {
+    teardown();
+    return false;
+  }
   const { autoPrune } = await chrome.storage.sync.get(STORAGE_KEY);
   if (autoPrune === false) return false;
 
@@ -58,7 +102,7 @@ const scheduleScan = () => {
   if (scanTimer !== null) return;
   scanTimer = setTimeout(() => {
     scanTimer = null;
-    scan().catch((err) => console.error("[PruneR]", err));
+    scan().catch(handleScanError);
   }, 150);
 };
 
@@ -67,9 +111,9 @@ const scheduleScan = () => {
  * navigate client-side and diff rows mount lazily / as you scroll).
  */
 const setup = () => {
-  scan().catch((err) => console.error("[PruneR]", err));
+  scan().catch(handleScanError);
 
-  const observer = new MutationObserver(scheduleScan);
+  observer = new MutationObserver(scheduleScan);
   observer.observe(document.body, { childList: true, subtree: true });
 };
 

--- a/src/options.html
+++ b/src/options.html
@@ -1,0 +1,244 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>PruneR Options</title>
+  <style>
+    :root {
+      --bg: #ffffff;
+      --fg: #24292f;
+      --muted: #57606a;
+      --border: #d0d7de;
+      --accent: #1f883d;
+      --accent-hover: #1a7f37;
+      --switch-bg: #d0d7de;
+      --card-bg: #f6f8fa;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg: #0d1117;
+        --fg: #f0f6fc;
+        --muted: #9198a1;
+        --border: #30363d;
+        --accent: #238636;
+        --accent-hover: #2ea043;
+        --switch-bg: #484f58;
+        --card-bg: #161b22;
+      }
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica,
+        Arial, sans-serif;
+      background: var(--bg);
+      color: var(--fg);
+      display: flex;
+      justify-content: center;
+      padding: 40px 16px;
+    }
+
+    .container {
+      width: 100%;
+      max-width: 560px;
+    }
+
+    header {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      margin-bottom: 24px;
+    }
+
+    header img {
+      width: 48px;
+      height: 48px;
+      border-radius: 8px;
+    }
+
+    header h1 {
+      font-size: 20px;
+      margin: 0;
+    }
+
+    header p {
+      margin: 2px 0 0;
+      font-size: 12px;
+      color: var(--muted);
+    }
+
+    .card {
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 16px;
+      margin-bottom: 16px;
+      background: var(--card-bg);
+    }
+
+    .setting {
+      display: flex;
+      align-items: flex-start;
+      gap: 16px;
+    }
+
+    .setting .text {
+      flex: 1;
+    }
+
+    .setting h2 {
+      font-size: 15px;
+      margin: 0 0 4px;
+    }
+
+    .setting p {
+      font-size: 13px;
+      color: var(--muted);
+      margin: 0;
+      line-height: 1.45;
+    }
+
+    .switch {
+      position: relative;
+      width: 44px;
+      height: 24px;
+      flex-shrink: 0;
+    }
+
+    .switch input {
+      opacity: 0;
+      width: 0;
+      height: 0;
+    }
+
+    .slider {
+      position: absolute;
+      cursor: pointer;
+      inset: 0;
+      background: var(--switch-bg);
+      border-radius: 24px;
+      transition: background 0.15s ease;
+    }
+
+    .slider::before {
+      content: "";
+      position: absolute;
+      height: 18px;
+      width: 18px;
+      left: 3px;
+      top: 3px;
+      background: #ffffff;
+      border-radius: 50%;
+      transition: transform 0.15s ease;
+    }
+
+    .switch input:checked + .slider {
+      background: var(--accent);
+    }
+
+    .switch input:checked + .slider::before {
+      transform: translateX(20px);
+    }
+
+    .switch input:focus-visible + .slider {
+      outline: 2px solid var(--accent);
+      outline-offset: 2px;
+    }
+
+    .blurb {
+      font-size: 13px;
+      color: var(--muted);
+      line-height: 1.5;
+    }
+
+    .blurb code {
+      background: var(--card-bg);
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      padding: 1px 5px;
+      font-size: 12px;
+    }
+
+    .badge-demo {
+      display: inline-block;
+      min-width: 20px;
+      padding: 1px 6px;
+      border-radius: 10px;
+      background: #6e7781;
+      color: #ffffff;
+      font-size: 11px;
+      font-weight: 600;
+      text-align: center;
+      margin-left: 2px;
+      vertical-align: middle;
+    }
+
+    footer {
+      font-size: 12px;
+      color: var(--muted);
+      text-align: center;
+      margin-top: 24px;
+    }
+
+    footer a {
+      color: var(--accent);
+      text-decoration: none;
+    }
+
+    footer a:hover {
+      text-decoration: underline;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <header>
+      <img src="../icons/icon48.png" alt="PruneR logo" />
+      <div>
+        <h1>PruneR</h1>
+        <p id="version">v0.0.0</p>
+      </div>
+    </header>
+
+    <div class="card">
+      <div class="setting">
+        <div class="text">
+          <h2>Auto-mark test files as viewed</h2>
+          <p>
+            Automatically check the "Viewed" box on test, snapshot, and mock
+            files in PR diffs so they stay out of your review flow.
+          </p>
+        </div>
+        <label class="switch">
+          <input type="checkbox" id="autoPrune" />
+          <span class="slider"></span>
+        </label>
+      </div>
+    </div>
+
+    <div class="card">
+      <h2 style="font-size: 15px; margin: 0 0 4px">Hide dependency PRs</h2>
+      <p class="blurb">
+        Click the PruneR toolbar icon on a
+        <code>&lt;owner&gt;/&lt;repo&gt;/pulls</code> page to toggle the
+        <code>-label:dependencies</code> filter. When active, the icon shows a
+        badge <span class="badge-demo">12</span> with the number of open
+        dependabot / dependency PRs currently hidden.
+      </p>
+    </div>
+
+    <footer>
+      <a href="https://github.com/aashutoshrathi/PruneR" target="_blank">
+        PruneR on GitHub
+      </a>
+    </footer>
+  </div>
+
+  <script src="options.js"></script>
+</body>
+</html>

--- a/src/options.html
+++ b/src/options.html
@@ -162,6 +162,7 @@
       border-radius: 4px;
       padding: 1px 5px;
       font-size: 12px;
+      white-space: nowrap;
     }
 
     .badge-demo {

--- a/src/options.html
+++ b/src/options.html
@@ -208,14 +208,14 @@
     <div class="card">
       <div class="setting">
         <div class="text">
-          <h2>Auto-mark test files as viewed</h2>
+          <h2 id="autoPruneLabel">Auto-mark test files as viewed</h2>
           <p>
             Automatically check the "Viewed" box on test, snapshot, and mock
             files in PR diffs so they stay out of your review flow.
           </p>
         </div>
         <label class="switch">
-          <input type="checkbox" id="autoPrune" />
+          <input type="checkbox" id="autoPrune" aria-labelledby="autoPruneLabel" />
           <span class="slider"></span>
         </label>
       </div>
@@ -233,7 +233,7 @@
     </div>
 
     <footer>
-      <a href="https://github.com/aashutoshrathi/PruneR" target="_blank">
+      <a href="https://github.com/aashutoshrathi/PruneR" target="_blank" rel="noopener noreferrer">
         PruneR on GitHub
       </a>
     </footer>

--- a/src/options.js
+++ b/src/options.js
@@ -18,4 +18,12 @@ elements.autoPrune.addEventListener("change", async () => {
   await chrome.storage.sync.set({ [STORAGE_KEY]: autoPrune });
 });
 
+// Keep the toggle in sync when autoPrune is changed elsewhere, e.g. via the
+// toolbar context menu while the options page is open.
+chrome.storage.onChanged.addListener((changes, area) => {
+  if (area === "sync" && STORAGE_KEY in changes) {
+    elements.autoPrune.checked = changes[STORAGE_KEY].newValue !== false;
+  }
+});
+
 init();

--- a/src/options.js
+++ b/src/options.js
@@ -1,0 +1,21 @@
+const STORAGE_KEY = "autoPrune";
+
+const elements = {
+  autoPrune: document.getElementById("autoPrune"),
+  version: document.getElementById("version"),
+};
+
+const init = async () => {
+  const manifest = chrome.runtime.getManifest();
+  elements.version.textContent = `v${manifest.version}`;
+
+  const { autoPrune } = await chrome.storage.sync.get(STORAGE_KEY);
+  elements.autoPrune.checked = autoPrune !== false;
+};
+
+elements.autoPrune.addEventListener("change", async () => {
+  const autoPrune = elements.autoPrune.checked;
+  await chrome.storage.sync.set({ [STORAGE_KEY]: autoPrune });
+});
+
+init();

--- a/src/prune.js
+++ b/src/prune.js
@@ -1,0 +1,220 @@
+/**
+ * PruneR – pure logic for spotting test files on GitHub PR diff pages.
+ *
+ * Kept free of DOM wiring (no storage, no observer, no listener setup) so the
+ * rules here can be unit-tested in isolation. `content.js` drives all of this
+ * against the live page.
+ *
+ * GitHub ships two diff experiences and the markup keeps changing, so path
+ * resolution leans on a multi-stage fallback instead of a single selector:
+ *   • New React UI ("/pull/N/changes"): `button[aria-label="Viewed"]` whose
+ *     state is `aria-pressed`. The full path usually lives on a neighbouring
+ *     "Expand all lines" button (`data-file-path`) or must be looked up in the
+ *     file tree via the shared `#diff-<id>` anchor.
+ *   • Classic UI ("/pull/N/files"): `input[type="checkbox"][name="viewed"]`.
+ */
+"use strict";
+
+const PROCESSED_ATTR = "data-pruner-marked";
+
+const TEST_FILE_PATTERNS = [
+  /\.test\.(ts|tsx|js|jsx|mjs|cjs)$/,
+  /\.spec\.(ts|tsx|js|jsx|mjs|cjs)$/,
+  /(^|\/)__tests__\//,
+  /(^|\/)test\//,
+  /(^|\/)tests\//,
+  /(^|\/)__mocks__\//,
+  /(^|\/)__fixtures__\//,
+  /(^|\/)__snapshots__\//,
+  /\.snap$/,
+  /(^|\/)storybook\//i,
+  /\.stories\.(ts|tsx|js|jsx)$/,
+  /(^|\/)mocks?\//i,
+  /(^|\/)fixtures?\//i,
+  /(^|\/)testing\//i,
+];
+
+// Attributes that carry a full file path on GitHub's containers/buttons.
+const PATH_ATTRS = [
+  "data-tagsearch-path",
+  "data-file-path",
+  "data-path",
+  "data-clipboard-text",
+];
+
+const PATH_ATTR_SELECTOR = PATH_ATTRS.map((a) => `[${a}]`).join(", ");
+
+// Controls that toggle the "Viewed" state in either UI. State (not presence)
+// decides whether a control still needs marking, so we look at all of them.
+const CONTROL_SELECTOR = [
+  'button[aria-label="Viewed"]',
+  'button[aria-label="Not Viewed"]',
+  'input[type="checkbox"][name="viewed"]',
+  ".js-reviewed-checkbox",
+].join(", ");
+
+// GitHub pads file-path links with zero-width spaces, word joiners, and
+// bidirectional control chars so the truncated middle renders nicely.
+// Strip them all before pattern matching.
+const cleanPath = (text) =>
+  (text || "").replace(/[\u200B-\u200F\u202A-\u202E\u2060-\u2069\uFEFF]/g, "").trim();
+
+const isTestFile = (filePath) =>
+  TEST_FILE_PATTERNS.some((pattern) => pattern.test(filePath));
+
+/**
+ * Read the "Viewed" state from a control, handling both the classic checkbox
+ * and the new React button (aria-pressed / aria-checked — and the odd case
+ * where the button's label carries the state but no ARIA state attribute).
+ */
+const isViewed = (el) => {
+  if (!el) return false;
+  if (el.tagName === "INPUT") return Boolean(el.checked);
+  const pressed = el.getAttribute("aria-pressed");
+  if (pressed !== null) return pressed === "true";
+  const checked = el.getAttribute("aria-checked");
+  if (checked !== null) return checked === "true";
+  return (el.getAttribute("aria-label") || "").trim().toLowerCase() === "viewed";
+};
+
+/**
+ * Click a button or check a checkbox the way GitHub expects. Inputs get the
+ * event pair React listens for (input + change); buttons just get clicked.
+ */
+const markControl = (el) => {
+  if (el.tagName === "INPUT") {
+    el.checked = true;
+    el.dispatchEvent(new Event("input", { bubbles: true, cancelable: true }));
+    el.dispatchEvent(new Event("change", { bubbles: true, cancelable: true }));
+  } else {
+    el.click();
+  }
+};
+
+/**
+ * Try to read a file path off a single element:
+ *   1. known path data-attributes
+ *   2. title containing a "/" (bare filenames are ambiguous — skip them)
+ *   3. aria-label of the shape "...: <path>"
+ */
+const pathFromElement = (el) => {
+  if (!el) return null;
+  const attr = el.getAttribute;
+  if (typeof attr !== "function") return null;
+
+  for (const name of PATH_ATTRS) {
+    const value = attr.call(el, name);
+    if (value && value.trim()) return cleanPath(value);
+  }
+
+  const title = attr.call(el, "title");
+  if (title && title.includes("/")) return cleanPath(title);
+
+  const aria = attr.call(el, "aria-label");
+  if (aria) {
+    const match = aria.match(/\:\s*([^:]+)$/);
+    if (match && match[1].trim()) return cleanPath(match[1]);
+  }
+
+  return null;
+};
+
+/**
+ * Resolve a diff anchor (`<a href="#diff-…">`) to a real path via the file
+ * tree, whose items share the anchor id and carry the full path in `title`.
+ */
+const treePathForAnchor = (doc, container) => {
+  const anchor = container.querySelector('a[href^="#diff-"]');
+  if (!anchor) return null;
+  const id = anchor.getAttribute("href").slice(1);
+  const selector = `a[data-testid="file-tree-list-item"][href="#${id}"]`;
+  const item = doc.querySelector(selector);
+  if (item) {
+    const path = cleanPath(item.getAttribute("title") || item.textContent);
+    if (path) return path;
+  }
+  return null;
+};
+
+/**
+ * Find the file a control belongs to. Returns { path, container } or null.
+ *
+ * First tries well-known single-file containers, then walks up from the
+ * control looking for a path-bearing element (the new UI keeps it on a
+ * neighbouring button). The walk stops the moment an ancestor also contains
+ * another unviewed control — past that point we'd be attributing a neighbour's
+ * file to this control.
+ */
+const resolveFile = (control, doc, controls) => {
+  const known = control.closest(
+    '[data-diff-header-wrapper], [data-tagsearch-path], [data-file-path], ' +
+      '[data-testid="file-tree-list-item"], [data-path], .file-header'
+  );
+  if (known) {
+    const path =
+      pathFromElement(known) ||
+      pathFromElement(known.querySelector(PATH_ATTR_SELECTOR)) ||
+      treePathForAnchor(doc, known);
+    if (path) return { path, container: known };
+  }
+
+  let el = control;
+  for (let depth = 0; el && depth < 30; depth++) {
+    // Stop the moment an ancestor also contains another unviewed control —
+    // past that point we'd be attributing a neighbour's file to this control.
+    if (controls.some((o) => o !== control && el.contains(o))) return null;
+
+    const direct = pathFromElement(el);
+    if (direct) return { path: direct, container: el };
+
+    const nested = el.querySelector ? el.querySelector(PATH_ATTR_SELECTOR) : null;
+    const nestedPath = nested ? pathFromElement(nested) : null;
+    if (nestedPath) return { path: nestedPath, container: el };
+
+    el = el.parentElement;
+  }
+  return null;
+};
+
+/**
+ * Collect every unviewed test-file control on the page that still needs
+ * marking, paired with the DOM container it was resolved through (used to
+ * stamp PROCESSED_ATTR) and the action that marks it seen.
+ */
+const collectMarks = (doc, processedPaths) => {
+  const controls = Array.from(doc.querySelectorAll(CONTROL_SELECTOR)).filter(
+    (el) => !isViewed(el)
+  );
+
+  const actions = [];
+  for (const control of controls) {
+    if (control.closest(`[${PROCESSED_ATTR}]`)) continue;
+
+    const resolved = resolveFile(control, doc, controls);
+    if (!resolved || processedPaths.has(resolved.path)) continue;
+    if (!isTestFile(resolved.path)) continue;
+
+    actions.push({
+      el: control,
+      container: resolved.container,
+      path: resolved.path,
+      mark: () => markControl(control),
+    });
+  }
+  return actions;
+};
+
+const PruneR = {
+  PROCESSED_ATTR,
+  TEST_FILE_PATTERNS,
+  cleanPath,
+  isTestFile,
+  isViewed,
+  markControl,
+  resolveFile,
+  collectMarks,
+};
+
+if (typeof window !== "undefined") {
+  window.PruneR = PruneR;
+}

--- a/test-utils/chrome-mock.js
+++ b/test-utils/chrome-mock.js
@@ -1,0 +1,105 @@
+"use strict";
+
+/**
+ * A tiny in-memory `chrome` API mock for the node:test suite. Captures the
+ * event handlers the extension registers so tests can fire them, and records
+ * calls for assertions.
+ */
+function makeChromeMock({ manifest, storage: initialStorage = {} } = {}) {
+  const storage = { ...initialStorage };
+  const storageListeners = new Set();
+  const listeners = new Map();
+  const calls = { contextMenusCreate: [], contextMenusUpdate: [], tabUpdates: [] };
+
+  const on = (name) => ({
+    addListener(cb) {
+      const set = listeners.get(name) || new Set();
+      set.add(cb);
+      listeners.set(name, set);
+    },
+    removeListener(cb) {
+      listeners.get(name)?.delete(cb);
+    },
+    hasListener(cb) {
+      return listeners.get(name)?.has(cb) || false;
+    },
+  });
+
+  const runtime = {
+    getManifest: () => manifest,
+    openOptionsPage: async () => {},
+    onInstalled: on("runtime.onInstalled"),
+    onStartup: on("runtime.onStartup"),
+  };
+
+  const sync = {
+    async get(keysOrNull) {
+      if (keysOrNull == null) return { ...storage };
+      const keys = Array.isArray(keysOrNull) ? keysOrNull : [keysOrNull];
+      const out = {};
+      for (const key of keys) {
+        if (key in storage) out[key] = storage[key];
+      }
+      return out;
+    },
+    async set(values) {
+      const changes = {};
+      for (const [key, value] of Object.entries(values)) {
+        changes[key] = { oldValue: storage[key], newValue: value };
+        storage[key] = value;
+      }
+      for (const cb of storageListeners) cb(changes, "sync");
+    },
+    async remove(keysOrNull) {
+      const keys = Array.isArray(keysOrNull) ? keysOrNull : [keysOrNull];
+      for (const key of keys) {
+        if (key in storage) {
+          delete storage[key];
+        }
+      }
+    },
+  };
+
+  const chrome = {
+    storage: {
+      sync,
+      onChanged: { addListener: (cb) => storageListeners.add(cb) },
+    },
+    contextMenus: {
+      removeAll: async () => {},
+      create: (opts) => calls.contextMenusCreate.push(opts),
+      update: (id, opts) => calls.contextMenusUpdate.push({ id, opts }),
+      onClicked: on("contextMenus.onClicked"),
+    },
+    runtime,
+    tabs: {
+      query: async () => [],
+      update: async (id, opts) => calls.tabUpdates.push({ id, opts }),
+      onActivated: on("tabs.onActivated"),
+      onUpdated: on("tabs.onUpdated"),
+    },
+    action: {
+      setBadgeBackgroundColor: async () => {},
+      setBadgeText: async (opts) => {
+        calls.badgeText = opts.text;
+      },
+      setIcon: async () => {},
+      onClicked: on("action.onClicked"),
+    },
+  };
+
+  return {
+    chrome,
+    storage,
+    listeners,
+    calls,
+    fire(eventName, ...args) {
+      for (const cb of listeners.get(eventName) || []) cb(...args);
+    },
+    async fireAsync(eventName, ...args) {
+      for (const cb of listeners.get(eventName) || []) await cb(...args);
+    },
+  };
+}
+
+module.exports = { makeChromeMock };

--- a/test-utils/dom.js
+++ b/test-utils/dom.js
@@ -1,0 +1,138 @@
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+const { JSDOM } = require("jsdom");
+
+const SRC_DIR = path.join(__dirname, "..", "src");
+
+const readSource = (name) => fs.readFileSync(path.join(SRC_DIR, name), "utf8");
+
+/**
+ * Build a jsdom window whose scripts come straight from src/ so the tests
+ * exercise the real shipped code. `beforeParse` lets each test inject its own
+ * `chrome` mock (and any other globals) before the page scripts run.
+ *
+ * Scripts are inlined in the document while readyState is "loading", which is
+ * exactly how Chrome injects content scripts at `document_idle`.
+ */
+function loadPage({ html, scripts, url, beforeParse }) {
+  const dom = new JSDOM(`<!DOCTYPE html><html><body>${html}</body></html>`, {
+    url: url || "https://github.com/acme/repo/pull/42/files",
+    runScripts: "dangerously",
+    pretendToBeVisual: true,
+    beforeParse(window) {
+      if (beforeParse) beforeParse(window);
+    },
+  });
+
+  const window = dom.window;
+  for (const name of scripts) {
+    const doc = window.document;
+    const script = doc.createElement("script");
+    script.textContent = readSource(name);
+    doc.body.appendChild(script);
+  }
+  return window;
+}
+
+const tick = (ms = 30) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Poll until `predicate` is truthy or the timeout elapses. Lets tests assert on
+ * things the async observer / debounce / storage reads settle in to.
+ */
+async function waitFor(predicate, { timeout = 1000, interval = 10 } = {}) {
+  const start = Date.now();
+  while (Date.now() - start < timeout) {
+    if (predicate()) return true;
+    await tick(interval);
+  }
+  return false;
+}
+
+// ---- fixture builders (mirror the real GitHub DOM as of 2026) ----
+
+const anchorIdFor = (path) =>
+  "diff-" + Buffer.from(path).toString("hex").slice(0, 12);
+
+/**
+ * The new React PR review UI. The file container carries no path itself — the
+ * path lives on a neighbouring "Expand all lines" button (`data-file-path`),
+ * which younger diffs with no collapsed lines can lack entirely.
+ */
+function newUiFile(doc, path, { viewed = false, includeExpand = true } = {}) {
+  const id = anchorIdFor(path);
+  const container = doc.createElement("div");
+  container.id = id;
+  container.className = "diffEntry-hash123";
+
+  const header = doc.createElement("div");
+  header.className = "diffHeader-hash456";
+  header.setAttribute("data-diff-header-wrapper", "");
+  container.appendChild(header);
+
+  if (includeExpand) {
+    const expand = doc.createElement("button");
+    expand.setAttribute("aria-label", `Expand all lines: ${path}`);
+    expand.setAttribute("data-file-path", path);
+    header.appendChild(expand);
+  }
+
+  const anchor = doc.createElement("a");
+  anchor.href = `#${id}`;
+  anchor.textContent = path;
+  header.appendChild(anchor);
+
+  const button = doc.createElement("button");
+  button.setAttribute("aria-label", "Viewed");
+  button.setAttribute("aria-pressed", viewed ? "true" : "false");
+  header.appendChild(button);
+
+  return { root: container, container, header, button, anchor, path };
+}
+
+/**
+ * The classic /files UI: every file header carries `[data-tagsearch-path]`
+ * and a native `input[name="viewed"]` checkbox.
+ */
+function classicFile(doc, path) {
+  const header = doc.createElement("div");
+  header.className = "file-header";
+  header.setAttribute("data-tagsearch-path", path);
+
+  const checkbox = doc.createElement("input");
+  checkbox.type = "checkbox";
+  checkbox.name = "viewed";
+  header.appendChild(checkbox);
+
+  const anchor = doc.createElement("a");
+  anchor.href = `#${anchorIdFor(path)}`;
+  header.appendChild(anchor);
+
+  return { header, checkbox, path };
+}
+
+/**
+ * The file tree sidebar. Items link to the same `#diff-<id>` anchors as diff
+ * containers and carry the full path in `title`.
+ */
+function fileTreeItem(doc, path) {
+  const item = doc.createElement("a");
+  item.setAttribute("data-testid", "file-tree-list-item");
+  item.href = `#${anchorIdFor(path)}`;
+  item.setAttribute("title", path);
+  return item;
+}
+
+module.exports = {
+  SRC_DIR,
+  readSource,
+  loadPage,
+  tick,
+  waitFor,
+  anchorIdFor,
+  newUiFile,
+  classicFile,
+  fileTreeItem,
+};

--- a/test/background.test.js
+++ b/test/background.test.js
@@ -1,0 +1,118 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+
+const { loadPage, waitFor } = require("../test-utils/dom");
+const { makeChromeMock } = require("../test-utils/chrome-mock");
+
+const manifest = JSON.parse(fs.readFileSync("manifest.json", "utf8"));
+
+const HIDE = "-label%3Adependencies";
+const PRS_URL = "https://github.com/acme/repo/pulls";
+const REPO_URL = "https://github.com/acme/repo";
+
+const loadBackground = async ({
+  storage = {},
+  activeTabUrl = PRS_URL,
+  fetchImpl = () => ({ ok: true, json: async () => ({ total_count: 3 }) }),
+} = {}) => {
+  const mock = makeChromeMock({ manifest, storage });
+  mock.chrome.tabs.query = async () => [
+    { id: 1, url: activeTabUrl, active: true, currentWindow: true },
+  ];
+  const window = loadPage({
+    html: "",
+    url: "chrome-extension://abc/background.html",
+    scripts: ["background.js"],
+    beforeParse(w) {
+      w.chrome = mock.chrome;
+      w.fetch = fetchImpl;
+    },
+  });
+  await new Promise((r) => setTimeout(r, 20));
+  return { window, mock };
+};
+
+test("onInstalled creates the context menus and defaults autoPrune on", async () => {
+  const { mock } = await loadBackground();
+  await mock.fireAsync("runtime.onInstalled", { reason: "install" });
+
+  const createdIds = mock.calls.contextMenusCreate.map((c) => c.id);
+  assert.ok(createdIds.includes("auto-prune-toggle"));
+  assert.ok(createdIds.includes("open-options"));
+  assert.equal(mock.storage.autoPrune, true);
+  assert.equal(mock.storage.version, `v${manifest.version}`);
+});
+
+test("onInstalled does not override a user's saved autoPrune setting", async () => {
+  const { mock } = await loadBackground({ storage: { autoPrune: false } });
+  await mock.fireAsync("runtime.onInstalled", { reason: "install" });
+  assert.equal(mock.storage.autoPrune, false);
+});
+
+test("context menu toggles autoPrune and updates the menu title", async () => {
+  const { mock } = await loadBackground({ storage: { autoPrune: true } });
+  await mock.fireAsync("contextMenus.onClicked", { menuItemId: "auto-prune-toggle" });
+
+  assert.equal(mock.storage.autoPrune, false);
+  const update = mock.calls.contextMenusUpdate.at(-1);
+  assert.equal(update.id, "auto-prune-toggle");
+  assert.ok(!update.opts.title.includes("✓"));
+
+  await mock.fireAsync("contextMenus.onClicked", { menuItemId: "auto-prune-toggle" });
+  assert.equal(mock.storage.autoPrune, true);
+  assert.ok(mock.calls.contextMenusUpdate.at(-1).opts.title.includes("✓"));
+});
+
+test("context menu opens the options page", async () => {
+  const { mock } = await loadBackground();
+  let optionsOpened = false;
+  mock.chrome.runtime.openOptionsPage = async () => {
+    optionsOpened = true;
+  };
+  await mock.fireAsync("contextMenus.onClicked", { menuItemId: "open-options" });
+  assert.equal(optionsOpened, true);
+});
+
+test("a storage change re-syncs the menu title", async () => {
+  const { mock } = await loadBackground({ storage: { autoPrune: true } });
+  await mock.chrome.storage.sync.set({ autoPrune: false });
+  await waitFor(() => mock.calls.contextMenusUpdate.length > 0);
+  assert.ok(!mock.calls.contextMenusUpdate.at(-1).opts.title.includes("✓"));
+});
+
+test("clicking the toolbar icon on a PR list page toggles the filter and shows the badge", async () => {
+  const { mock } = await loadBackground();
+  await mock.fireAsync("action.onClicked", { id: 1, url: PRS_URL });
+
+  const update = mock.calls.tabUpdates.at(-1);
+  assert.ok(update.opts.url.includes(HIDE), "expected the dependency filter query to be added");
+
+  assert.equal(mock.storage.state, true);
+  assert.equal(mock.storage.hiddenPRCount, 3);
+  assert.equal(mock.calls.badgeText, "3");
+});
+
+test("clicking the toolbar icon on a non-PR-list page does nothing", async () => {
+  const { mock } = await loadBackground({ activeTabUrl: REPO_URL });
+  await mock.fireAsync("action.onClicked", { id: 1, url: REPO_URL });
+
+  assert.equal(mock.calls.tabUpdates.length, 0);
+  assert.equal(mock.storage.state, undefined);
+});
+
+test("tabs.onUpdated keeps state and badge in sync with the active tab", async () => {
+  const { mock } = await loadBackground({ activeTabUrl: PRS_URL + "?" + HIDE + "+" });
+  mock.fire("tabs.onUpdated", 1, { status: "complete" }, { active: true });
+
+  await waitFor(() => mock.storage.state === true);
+  assert.equal(mock.storage.state, true);
+});
+
+test("more complex page that is not the PR list is ignored", async () => {
+  const { mock } = await loadBackground({ activeTabUrl: "https://github.com/acme/repo/issues/1" });
+  await mock.fireAsync("action.onClicked", { id: 1, url: "https://github.com/acme/repo/issues/1" });
+  assert.equal(mock.calls.tabUpdates.length, 0);
+});

--- a/test/background.test.js
+++ b/test/background.test.js
@@ -104,11 +104,54 @@ test("clicking the toolbar icon on a non-PR-list page does nothing", async () =>
 });
 
 test("tabs.onUpdated keeps state and badge in sync with the active tab", async () => {
-  const { mock } = await loadBackground({ activeTabUrl: PRS_URL + "?" + HIDE + "+" });
-  mock.fire("tabs.onUpdated", 1, { status: "complete" }, { active: true });
+  const filtered = PRS_URL + "?" + HIDE + "+";
+  const { mock } = await loadBackground({ activeTabUrl: filtered });
+  mock.fire("tabs.onUpdated", 1, { status: "complete" }, { active: true, url: filtered });
 
   await waitFor(() => mock.storage.state === true);
   assert.equal(mock.storage.state, true);
+  assert.equal(mock.storage.hiddenPRCount, 3);
+  assert.equal(mock.calls.badgeText, "3");
+});
+
+test("tabs.onUpdated ignores non-complete or non-active updates", async () => {
+  const { mock } = await loadBackground({ storage: { state: false } });
+  mock.fire("tabs.onUpdated", 1, { status: "loading" }, { active: true });
+  mock.fire("tabs.onUpdated", 1, { status: "complete" }, { active: false });
+
+  await new Promise((r) => setTimeout(r, 30));
+  assert.equal(mock.storage.state, false);
+});
+
+test("tabs.onActivated recomputes the badge for the newly active tab", async () => {
+  const { mock } = await loadBackground({ activeTabUrl: PRS_URL + "?" + HIDE + "+" });
+  await mock.fireAsync("tabs.onActivated", { tabId: 1 });
+
+  assert.equal(mock.storage.state, true);
+  assert.equal(mock.storage.hiddenPRCount, 3);
+  assert.equal(mock.calls.badgeText, "3");
+});
+
+test("an inactive, filtered tab is not fetched for a badge count", async () => {
+  const { mock } = await loadBackground({ activeTabUrl: REPO_URL });
+  await mock.fireAsync("tabs.onActivated", { tabId: 1 });
+
+  assert.equal(mock.storage.state, false);
+  assert.equal(mock.storage.hiddenPRCount, null);
+  assert.equal(mock.calls.badgeText, "");
+});
+
+test("turning the filter off clears the stored badge count", async () => {
+  const filtered = PRS_URL + "?" + HIDE + "+";
+  const { mock } = await loadBackground({
+    storage: { state: true, hiddenPRCount: 3 },
+    activeTabUrl: filtered,
+  });
+  await mock.fireAsync("action.onClicked", { id: 1, url: filtered });
+
+  assert.equal(mock.storage.state, false);
+  assert.equal(mock.storage.hiddenPRCount, null);
+  assert.equal(mock.calls.badgeText, "");
 });
 
 test("more complex page that is not the PR list is ignored", async () => {

--- a/test/content.test.js
+++ b/test/content.test.js
@@ -1,0 +1,213 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { loadPage, tick, waitFor, anchorIdFor } = require("../test-utils/dom");
+
+const URL = "https://github.com/acme/repo/pull/42/files";
+
+const htmlNewFile = (path, { viewed = false, includeExpand = true } = {}) => {
+  const id = anchorIdFor(path);
+  const expand = includeExpand
+    ? `<button aria-label="Expand all lines: ${path}" data-file-path="${path}"></button>`
+    : "";
+  return `<div id="${id}" class="diffEntry-hash123">
+    <div class="diffHeader-hash456" data-diff-header-wrapper="">
+      ${expand}
+      <a href="#${id}">${path}</a>
+      <button aria-label="Viewed" aria-pressed="${viewed ? "true" : "false"}">Viewed</button>
+    </div>
+  </div>`;
+};
+
+const htmlClassicFile = (path) =>
+  `<div class="file-header" data-tagsearch-path="${path}">
+    <input type="checkbox" name="viewed" />
+    <a href="#${anchorIdFor(path)}"></a>
+  </div>`;
+
+const htmlTreeItem = (path) =>
+  `<a data-testid="file-tree-list-item" href="#${anchorIdFor(path)}" title="${path}">${path}</a>`;
+
+const makeContentChrome = ({ autoPrune = true } = {}) => ({
+  storage: {
+    sync: {
+      get: async (key) => ({ [key]: autoPrune }),
+      set: async () => {},
+    },
+  },
+});
+
+const loadPageWith = ({ body, chrome }) =>
+  loadPage({
+    html: body,
+    url: URL,
+    scripts: ["prune.js", "content.js"],
+    beforeParse(window) {
+      window.chrome = chrome;
+      window.__clicks = [];
+      window.__changes = [];
+      window.addEventListener("click", (e) => window.__clicks.push(e.target), true);
+      window.addEventListener("change", (e) => window.__changes.push(e.target), true);
+      // Simulate GitHub's async server response: React flips the button state
+      // right after a successful "mark as viewed" request.
+      window.document.addEventListener(
+        "click",
+        (e) => {
+          const btn = e.target.closest && e.target.closest('button[aria-label="Viewed"]');
+          if (btn) btn.setAttribute("aria-pressed", "true");
+        },
+        true
+      );
+    },
+  });
+
+const getButton = (doc, path) => {
+  const id = anchorIdFor(path);
+  const holder = doc.getElementById(id);
+  return holder.querySelector('button[aria-label="Viewed"]');
+};
+
+test("marks a new-UI test file as viewed as soon as it is in the DOM", async () => {
+  const window = loadPageWith({
+    body: htmlNewFile("src/App.test.tsx"),
+    chrome: makeContentChrome(),
+  });
+
+  const clicked = await waitFor(() =>
+    window.__clicks.some((el) => el.getAttribute && el.getAttribute("aria-label") === "Viewed")
+  );
+  assert.ok(clicked, "expected the test file's Viewed button to be clicked");
+
+  const button = getButton(window.document, "src/App.test.tsx");
+  assert.equal(button.getAttribute("aria-pressed"), "true");
+});
+
+test("marks a classic-UI test file by checking its checkbox and firing change", async () => {
+  const window = loadPageWith({
+    body: htmlClassicFile("src/util.spec.ts"),
+    chrome: makeContentChrome(),
+  });
+
+  const changed = await waitFor(() =>
+    window.__changes.some((el) => el.name === "viewed")
+  );
+  assert.ok(changed, "expected a change event on the viewed checkbox");
+
+  const checkbox = window.document.querySelector('input[name="viewed"]');
+  assert.equal(checkbox.checked, true);
+});
+
+test("marks test files but leaves source files alone (new UI)", async () => {
+  const window = loadPageWith({
+    body:
+      htmlNewFile("src/App.test.tsx") +
+      htmlNewFile("src/components/Button.tsx") +
+      htmlNewFile("src/hooks/useAuth.spec.ts"),
+    chrome: makeContentChrome(),
+  });
+
+  await waitFor(() => window.__clicks.length >= 2);
+
+  assert.equal(getButton(window.document, "src/App.test.tsx").getAttribute("aria-pressed"), "true");
+  assert.equal(getButton(window.document, "src/hooks/useAuth.spec.ts").getAttribute("aria-pressed"), "true");
+  assert.equal(getButton(window.document, "src/components/Button.tsx").getAttribute("aria-pressed"), "false");
+});
+
+test("marks a new-UI test file whose path only exists in the file tree", async () => {
+  const window = loadPageWith({
+    body:
+      htmlNewFile("src/withoutExpand.test.ts", { includeExpand: false }) +
+      htmlTreeItem("src/withoutExpand.test.ts"),
+    chrome: makeContentChrome(),
+  });
+
+  const clicked = await waitFor(() =>
+    window.__clicks.some(
+      (el) => el.getAttribute && el.getAttribute("aria-label") === "Viewed"
+    )
+  );
+  assert.ok(clicked, "expected the file to be marked via the file tree path");
+});
+
+test("does nothing for already-viewed test files", async () => {
+  const window = loadPageWith({
+    body: htmlNewFile("src/App.test.tsx", { viewed: true }),
+    chrome: makeContentChrome(),
+  });
+
+  await tick(200);
+  assert.equal(window.__clicks.length, 0);
+});
+
+test("marks late-mounted files as soon as they appear (lazy / virtualized rendering)", async () => {
+  const window = loadPageWith({
+    body: htmlNewFile("src/first.test.ts"),
+    chrome: makeContentChrome(),
+  });
+
+  const first = await waitFor(() => window.__clicks.length >= 1);
+  assert.ok(first);
+
+  // Simulate GitHub mounting another diff row later (scroll / lazy load).
+  const temp = window.document.createElement("div");
+  temp.innerHTML = htmlNewFile("src/second.test.ts");
+  const late = temp.firstElementChild;
+  window.document.body.appendChild(late);
+
+  const gotLate = await waitFor(() =>
+    window.__clicks.some((el) => {
+      const id = anchorIdFor("src/second.test.ts");
+      return (
+        el.closest &&
+        el.closest(`#${id}`) &&
+        el.setAttribute &&
+        el.getAttribute("aria-label") === "Viewed"
+      );
+    })
+  );
+  assert.ok(gotLate, "expected the late-mounted test file to be marked");
+
+  const btn = getButton(window.document, "src/second.test.ts");
+  assert.equal(btn.getAttribute("aria-pressed"), "true");
+});
+
+test("does not re-toggle a marked file after a virtualized row is remounted", async () => {
+  const window = loadPageWith({
+    body: htmlNewFile("src/remount.test.ts"),
+    chrome: makeContentChrome(),
+  });
+
+  await waitFor(() => window.__clicks.length >= 1);
+  const clicksAfterFirst = window.__clicks.length;
+
+  // React tears the row down and mounts a fresh one whose control initially
+  // looks unviewed (aria-pressed=false) before it syncs with the server.
+  const oldId = anchorIdFor("src/remount.test.ts");
+  window.document.getElementById(oldId).remove();
+
+  const temp = window.document.createElement("div");
+  temp.innerHTML = htmlNewFile("src/remount.test.ts");
+  window.document.body.appendChild(temp.firstElementChild);
+
+  await tick(250);
+  assert.equal(
+    window.__clicks.length,
+    clicksAfterFirst,
+    "remount must not click the already-marked file again"
+  );
+});
+
+test("respects the autoPrune off setting", async () => {
+  const window = loadPageWith({
+    body:
+      htmlNewFile("src/App.test.tsx") +
+      htmlClassicFile("src/util.spec.ts"),
+    chrome: makeContentChrome({ autoPrune: false }),
+  });
+
+  await tick(250);
+  assert.equal(window.__clicks.length, 0);
+  assert.equal(window.document.querySelector('input[name="viewed"]').checked, false);
+});

--- a/test/content.test.js
+++ b/test/content.test.js
@@ -31,6 +31,7 @@ const htmlTreeItem = (path) =>
   `<a data-testid="file-tree-list-item" href="#${anchorIdFor(path)}" title="${path}">${path}</a>`;
 
 const makeContentChrome = ({ autoPrune = true } = {}) => ({
+  runtime: { id: "test-extension-id" },
   storage: {
     sync: {
       get: async (key) => ({ [key]: autoPrune }),
@@ -196,6 +197,50 @@ test("does not re-toggle a marked file after a virtualized row is remounted", as
     window.__clicks.length,
     clicksAfterFirst,
     "remount must not click the already-marked file again"
+  );
+});
+
+test("does nothing when the extension context is already invalidated", async () => {
+  const chrome = makeContentChrome();
+  // A content script orphaned by an extension reload has no runtime.id.
+  chrome.runtime.id = undefined;
+
+  const window = loadPageWith({
+    body: htmlNewFile("src/App.test.tsx"),
+    chrome,
+  });
+
+  await tick(250);
+  assert.equal(window.__clicks.length, 0);
+});
+
+test("stops scanning once the extension context is invalidated mid-session", async () => {
+  const chrome = makeContentChrome();
+  const window = loadPageWith({
+    body: htmlNewFile("src/first.test.ts"),
+    chrome,
+  });
+
+  await waitFor(() => window.__clicks.length >= 1);
+  const clicksAfterFirst = window.__clicks.length;
+
+  // The extension is reloaded out from under the page: runtime.id goes away
+  // and every chrome.* call now throws.
+  chrome.runtime.id = undefined;
+  chrome.storage.sync.get = async () => {
+    throw new Error("Extension context invalidated.");
+  };
+
+  // A new diff row mounts, which would normally trigger a scan.
+  const temp = window.document.createElement("div");
+  temp.innerHTML = htmlNewFile("src/second.test.ts");
+  window.document.body.appendChild(temp.firstElementChild);
+
+  await tick(250);
+  assert.equal(
+    window.__clicks.length,
+    clicksAfterFirst,
+    "an invalidated context must not keep scanning"
   );
 });
 

--- a/test/options.test.js
+++ b/test/options.test.js
@@ -1,0 +1,63 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+
+const { loadPage, waitFor } = require("../test-utils/dom");
+const { makeChromeMock } = require("../test-utils/chrome-mock");
+
+const manifest = JSON.parse(fs.readFileSync("manifest.json", "utf8"));
+
+const optionsHtml = `
+  <p id="version">v0.0.0</p>
+  <input type="checkbox" id="autoPrune" />
+`;
+
+const loadOptions = async (storage) => {
+  const mock = makeChromeMock({ manifest, storage });
+  const window = loadPage({
+    html: optionsHtml,
+    url: "chrome-extension://abc/options.html",
+    scripts: ["options.js"],
+    beforeParse(w) {
+      w.chrome = mock.chrome;
+    },
+  });
+  const expected = storage.autoPrune !== false;
+  await waitFor(
+    () =>
+      window.document.getElementById("version").textContent !== "v0.0.0" &&
+      window.document.getElementById("autoPrune").checked === expected
+  );
+  return { window, mock };
+};
+
+test("init shows the manifest version", async () => {
+  const { window } = await loadOptions({ autoPrune: true });
+  assert.equal(
+    window.document.getElementById("version").textContent,
+    `v${manifest.version}`
+  );
+});
+
+test("init checks the toggle when autoPrune is enabled", async () => {
+  const { window } = await loadOptions({ autoPrune: true });
+  assert.equal(window.document.getElementById("autoPrune").checked, true);
+});
+
+test("init leaves the toggle unchecked when autoPrune is disabled", async () => {
+  const { window } = await loadOptions({ autoPrune: false });
+  assert.equal(window.document.getElementById("autoPrune").checked, false);
+});
+
+test("toggling the checkbox persists autoPrune to storage", async () => {
+  const { window, mock } = await loadOptions({ autoPrune: true });
+
+  const checkbox = window.document.getElementById("autoPrune");
+  checkbox.checked = false;
+  checkbox.dispatchEvent(new window.Event("change", { bubbles: true }));
+
+  await waitFor(() => mock.storage.autoPrune === false);
+  assert.equal(mock.storage.autoPrune, false);
+});

--- a/test/options.test.js
+++ b/test/options.test.js
@@ -61,3 +61,14 @@ test("toggling the checkbox persists autoPrune to storage", async () => {
   await waitFor(() => mock.storage.autoPrune === false);
   assert.equal(mock.storage.autoPrune, false);
 });
+
+test("an external autoPrune change stays in sync with the toggle", async () => {
+  const { window, mock } = await loadOptions({ autoPrune: true });
+
+  await mock.chrome.storage.sync.set({ autoPrune: false });
+
+  await waitFor(
+    () => window.document.getElementById("autoPrune").checked === false
+  );
+  assert.equal(window.document.getElementById("autoPrune").checked, false);
+});

--- a/test/prune.test.js
+++ b/test/prune.test.js
@@ -1,0 +1,234 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { loadPage, newUiFile, classicFile, fileTreeItem } = require("../test-utils/dom");
+
+const makeWindow = () =>
+  loadPage({ scripts: ["prune.js"], url: "https://github.com/acme/repo/pull/42/files" });
+
+test("isTestFile matches every documented pattern", () => {
+  const window = makeWindow();
+  const { isTestFile } = window.PruneR;
+  const matches = [
+    "src/button.test.ts",
+    "src/button.test.tsx",
+    "src/button.test.js",
+    "src/button.test.jsx",
+    "src/button.test.mjs",
+    "src/button.test.cjs",
+    "src/utils.spec.ts",
+    "src/utils.spec.tsx",
+    "src/utils.spec.mjs",
+    "__tests__/foo.ts",
+    "src/__tests__/foo.ts",
+    "test/setup.ts",
+    "tests/setup.ts",
+    "__mocks__/fs.ts",
+    "__fixtures__/data.json",
+    "fixtures/data.json",
+    "__snapshots__/button.test.tsx.snap",
+    "button.test.tsx.snap",
+    "src/components/stack.stories.tsx",
+    "src/components/stack.stories.ts",
+    "src/components/stack.stories.js",
+    "src/components/stack.stories.jsx",
+    "mocks/handlers.ts",
+    "mock/handlers.ts",
+    "testing/setup.ts",
+    "src/storybook/decorators.tsx",
+  ];
+  for (const path of matches) assert.ok(isTestFile(path), path);
+});
+
+test("isTestFile rejects regular source files", () => {
+  const window = makeWindow();
+  const { isTestFile } = window.PruneR;
+  const rejects = [
+    "src/App.tsx",
+    "src/useThing.ts",
+    "src/components/button.tsx",
+    "README.md",
+    "src/test.ts",
+    "src/controller.testing.ts",
+    "src/mock-server.ts",
+  ];
+  for (const path of rejects) assert.ok(!isTestFile(path), path);
+});
+
+test("cleanPath strips zero-width and bidirectional control chars", () => {
+  const window = makeWindow();
+  assert.equal(
+    window.PruneR.cleanPath("\u200bsrc\u2060/\u200bbutton.test.ts\u200b"),
+    "src/button.test.ts"
+  );
+});
+
+test("isViewed reads the classic checkbox state", () => {
+  const window = makeWindow();
+  const doc = window.document;
+  const cb = doc.createElement("input");
+  cb.type = "checkbox";
+  assert.equal(window.PruneR.isViewed(cb), false);
+  cb.checked = true;
+  assert.equal(window.PruneR.isViewed(cb), true);
+});
+
+test("isViewed reads the new UI button aria-pressed state", () => {
+  const window = makeWindow();
+  const doc = window.document;
+  const btn = doc.createElement("button");
+  btn.setAttribute("aria-label", "Viewed");
+  btn.setAttribute("aria-pressed", "false");
+  assert.equal(window.PruneR.isViewed(btn), false);
+  btn.setAttribute("aria-pressed", "true");
+  assert.equal(window.PruneR.isViewed(btn), true);
+});
+
+test("isViewed falls back to the label when aria-pressed is absent", () => {
+  const window = makeWindow();
+  const doc = window.document;
+  const notViewed = doc.createElement("button");
+  notViewed.setAttribute("aria-label", "Not Viewed");
+  assert.equal(window.PruneR.isViewed(notViewed), false);
+
+  const viewed = doc.createElement("button");
+  viewed.setAttribute("aria-label", "Viewed");
+  assert.equal(window.PruneR.isViewed(viewed), true);
+});
+
+test("markControl clicks a button and checks+notifies a checkbox", () => {
+  const window = makeWindow();
+  const doc = window.document;
+
+  const btn = doc.createElement("button");
+  let clicks = 0;
+  btn.addEventListener("click", () => clicks++);
+  window.PruneR.markControl(btn);
+  assert.equal(clicks, 1);
+
+  const checkbox = doc.createElement("input");
+  checkbox.type = "checkbox";
+  checkbox.name = "viewed";
+  let changes = 0;
+  checkbox.addEventListener("change", () => changes++);
+  window.PruneR.markControl(checkbox);
+  assert.equal(checkbox.checked, true);
+  assert.equal(changes, 1);
+});
+
+test("resolveFile resolves the new UI file via its sibling Expand-all button", () => {
+  const window = makeWindow();
+  const doc = window.document;
+  const { container, button } = newUiFile(doc, "src/features/notes/index.test.ts");
+  doc.body.appendChild(container);
+
+  const resolved = window.PruneR.resolveFile(button, doc, [button]);
+  assert.equal(resolved.path, "src/features/notes/index.test.ts");
+  assert.equal(resolved.container.className, "diffHeader-hash456");
+});
+
+test("resolveFile resolves a new UI file even when the path-bearing button is absent (via file tree)", () => {
+  const window = makeWindow();
+  const doc = window.document;
+  const testFile = newUiFile(doc, "src/bar.test.ts", { includeExpand: false });
+  doc.body.appendChild(testFile.container);
+  doc.body.appendChild(fileTreeItem(doc, "src/bar.test.ts"));
+
+  const resolved = window.PruneR.resolveFile(testFile.button, doc, [testFile.button]);
+  assert.equal(resolved.path, "src/bar.test.ts");
+});
+
+test("resolveFile resolves the classic UI via data-tagsearch-path", () => {
+  const window = makeWindow();
+  const doc = window.document;
+  const { header, checkbox } = classicFile(doc, "src/foo.spec.ts");
+  doc.body.appendChild(header);
+
+  const resolved = window.PruneR.resolveFile(checkbox, doc, [checkbox]);
+  assert.equal(resolved.path, "src/foo.spec.ts");
+  assert.equal(resolved.container, header);
+});
+
+test("resolveFile reads a path from an aria-label", () => {
+  const window = makeWindow();
+  const doc = window.document;
+
+  // Classic UI: the checkbox's own aria-label is "Viewed: <path>".
+  const checkbox = doc.createElement("input");
+  checkbox.type = "checkbox";
+  checkbox.name = "viewed";
+  checkbox.setAttribute("aria-label", "Viewed: src/mocks/handlers.ts");
+  doc.body.appendChild(checkbox);
+
+  const resolved = window.PruneR.resolveFile(checkbox, doc, [checkbox]);
+  assert.equal(resolved.path, "src/mocks/handlers.ts");
+});
+
+test("resolveFile stops at the file boundary and does not steal a neighbour's path", () => {
+  const window = makeWindow();
+  const doc = window.document;
+
+  // Two files sharing one wrapper. No well-known container attributes so the
+  // walk-up path is exercised; it must not attribute App.tsx to the test file.
+  const wrapper = doc.createElement("div");
+  wrapper.appendChild(newUiFile(doc, "src/App.tsx").container);
+  const testFile = newUiFile(doc, "src/App.test.tsx");
+  wrapper.appendChild(testFile.container);
+  doc.body.appendChild(wrapper);
+
+  const srcButton = wrapper.querySelectorAll('button[aria-pressed="false"]')[0];
+  const controls = [srcButton, testFile.button];
+  const resolved = window.PruneR.resolveFile(testFile.button, doc, controls);
+  assert.equal(resolved.path, "src/App.test.tsx");
+});
+
+test("resolveFile returns null when the path cannot be resolved", () => {
+  const window = makeWindow();
+  const doc = window.document;
+  const orphan = doc.createElement("button");
+  orphan.setAttribute("aria-label", "Viewed");
+  orphan.setAttribute("aria-pressed", "false");
+  doc.body.appendChild(orphan);
+
+  const resolved = window.PruneR.resolveFile(orphan, doc, [orphan]);
+  assert.equal(resolved, null);
+});
+
+test("collectMarks returns only unviewed test-file controls with a resolvable path", () => {
+  const window = makeWindow();
+  const doc = window.document;
+  const testFile = newUiFile(doc, "src/App.test.tsx");
+  const viewedTestFile = newUiFile(doc, "src/Util.spec.ts", { viewed: true });
+  const srcFile = newUiFile(doc, "src/App.tsx");
+  for (const file of [testFile, viewedTestFile, srcFile]) {
+    doc.body.appendChild(file.container);
+  }
+
+  const actions = window.PruneR.collectMarks(doc, new Set());
+  assert.equal(actions.length, 1);
+  assert.equal(actions[0].path, "src/App.test.tsx");
+  assert.equal(actions[0].el, testFile.button);
+});
+
+test("collectMarks skips paths already processed", () => {
+  const window = makeWindow();
+  const doc = window.document;
+  const testFile = newUiFile(doc, "src/App.test.tsx");
+  doc.body.appendChild(testFile.container);
+
+  const actions = window.PruneR.collectMarks(doc, new Set(["src/App.test.tsx"]));
+  assert.equal(actions.length, 0);
+});
+
+test("collectMarks skips controls nested under an already-marked container", () => {
+  const window = makeWindow();
+  const doc = window.document;
+  const testFile = newUiFile(doc, "src/App.test.tsx");
+  doc.body.appendChild(testFile.container);
+  testFile.container.setAttribute(window.PruneR.PROCESSED_ATTR, "1");
+
+  const actions = window.PruneR.collectMarks(doc, new Set());
+  assert.equal(actions.length, 0);
+});


### PR DESCRIPTION
Closes #2
Closes #5

## What

Two long-standing issues, fixed in one PR:

### 1. Options page (#5)
- New `src/options.html` + `src/options.js` page for configuring PruneR
- `options_ui` entry added to `manifest.json` (`open_in_tab: true`)
- Toggle for **Auto-mark test files as viewed** (kept in sync with the existing context-menu toggle via a `storage.onChanged` listener)
- "PruneR Options" entry added to the toolbar context menu

### 2. Show how many PRs are hidden (#2)
- While the `-label:dependencies` filter is active, the toolbar icon shows a **badge with the count of open dependency PRs** currently hidden
- Count is fetched from the GitHub Search API (`total_count` on `repo:owner/name is:pr is:open label:dependencies`); falls back gracefully (no badge) on private repos / network errors
- Badge clears when you toggle the filter off or leave the PR list page

## Notes
- Version bumped `0.1.1` → `0.2.0`
- README updated to document both features